### PR TITLE
feat: add git initial setup skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 | カテゴリ | 説明 | 配置先 | Skills数 | 詳細 |
 |---------|------|--------|---------|------|
-| `skills/` | Skill作成支援（Meta-Skills） | グローバル（~/.copilot/skills/） | 4 | [SKILLS_README.md](skills/SKILLS_README.md) |
+| `skills/` | Skill作成支援（Meta-Skills） | グローバル（~/.copilot/skills/） | 5 | [SKILLS_README.md](skills/SKILLS_README.md) |
 
 ### 📌 今後追加予定のカテゴリ
 
@@ -52,6 +52,7 @@ ls ~/.copilot/skills/
 # skill-quality-validation/
 # skill-template-generator/
 # skill-revision-guide/
+# skill-git-initial-setup/
 ```
 
 **Windowsの場合**:
@@ -93,7 +94,7 @@ python ~/.copilot/skills/skill-template-generator/scripts/generate_template.py
 
 #### 2. 品質検証
 ```bash
-# 作成したSkillの品質を55項目でチェック
+# 作成したSkillの品質を64項目でチェック
 python ~/.copilot/skills/skill-quality-validation/scripts/validate_skill.py path/to/SKILL.md
 ```
 
@@ -104,6 +105,7 @@ GitHub Copilot Chat内で直接Meta-Skillsを呼び出すことができます�
 - `@workspace /skill-quality-validation` - Skillの品質検証
 - `@workspace /skill-template-generator` - テンプレート生成支援
 - `@workspace /skill-revision-guide` - Skillの修正・バージョン管理
+- `@workspace /skill-git-initial-setup` - git init/clone時の保護を標準化
 
 ## 📚 ドキュメント
 
@@ -120,7 +122,7 @@ GitHub Copilot Chat内で直接Meta-Skillsを呼び出すことができます�
 1. **適切なカテゴリを選択** - 現在は`skills/`のみ、今後他カテゴリも追加予定
 2. **テンプレート生成** - `skill-template-generator`を使用
 3. **内容を作成** - `skill-writing-guide`を参考に記述
-4. **品質検証** - `skill-quality-validation`で55項目チェック
+4. **品質検証** - `skill-quality-validation`で64項目チェック
 5. **Pull Request作成** - レビュー後にマージ
 
 ### 既存Skillを改善する
@@ -154,11 +156,12 @@ GitHub Copilot Chat内で直接Meta-Skillsを呼び出すことができます�
 
 ### v1.0.0 (2026-02-12)
 - 初回リリース
-- Meta-Skills 4種を収録
+- Meta-Skills 5種を収録
   - skill-writing-guide
   - skill-quality-validation
   - skill-template-generator
   - skill-revision-guide
+  - skill-git-initial-setup
 - リポジトリ構造確立
 - Git管理開始
 

--- a/repository-structure-plan.md
+++ b/repository-structure-plan.md
@@ -214,7 +214,7 @@ GitHub Copilot Agent Skillsを作成・管理するための支援システム
 | Skill名 | 説明 | バージョン |
 |---------|------|-----------|
 | skill-writing-guide | Skill執筆ガイド | 1.0.0 |
-| skill-quality-validation | 55項目品質検証 | 2.0.0 |
+| skill-quality-validation | 64項目品質検証 | 2.0.0 |
 | skill-template-generator | テンプレート自動生成 | 1.0.0 |
 | skill-revision-guide | 修正・バージョン管理 | 1.0.0 |
 

--- a/skills/SKILLS_README.md
+++ b/skills/SKILLS_README.md
@@ -17,10 +17,11 @@ GitHub Copilot Agent Skillsを作成・管理するための支援システム
 | Skill名 | 説明 | バージョン | 主な機能 |
 |---------|------|-----------|---------|
 | [skill-writing-guide](skill-writing-guide/) | Skill執筆ガイド | 1.0.0 | ベストプラクティス、構造化手法、文章作成支援 |
-| [skill-quality-validation](skill-quality-validation/) | 55項目品質検証 | 2.0.0 | 自動品質チェック、スコアリング、改善提案 |
+| [skill-quality-validation](skill-quality-validation/) | 64項目品質検証 | 2.0.0 | 自動品質チェック、スコアリング、改善提案 |
 | [skill-template-generator](skill-template-generator/) | テンプレート自動生成 | 1.0.0 | SKILL.md/SKILL.ja.md雛形生成、構造作成 |
 | [skill-revision-guide](skill-revision-guide/) | 修正・バージョン管理 | 1.0.0 | 変更管理、CHANGELOG、英日同期支援 |
 | [skill-git-japanese-practices](skill-git-japanese-practices/) | Git日本語プラクティス | 1.0.0 | Conventional Commits、GitHubフロー、原子的コミット、コードレビュー |
+| [skill-git-initial-setup](skill-git-initial-setup/) | git初期セットアップ | 1.2.0 | git init/clone初期保護、GitHub保護ルール、フック設定 |
 
 ## 🔧 依存関係
 
@@ -53,7 +54,7 @@ GitHub Copilot Agent Skillsを作成・管理するための支援システム
 
 ### 2. skill-quality-validation
 
-**55項目の品質検証システム**
+**64項目の品質検証システム**
 
 - 構造の完全性チェック（15項目）
 - 内容の品質評価（20項目）
@@ -127,6 +128,21 @@ python ~/.copilot/skills/skill-template-generator/scripts/generate_template.py
 
 詳細: [skill-git-japanese-practices/SKILL.md](skill-git-japanese-practices/SKILL.md) | [日本語版](skill-git-japanese-practices/references/SKILL.ja.md)
 
+### 6. skill-git-initial-setup
+
+**git init/clone時のmain保護デフォルト設定ガイド**
+
+- GitHubブランチ保護ルールの設定
+- pre-commit/pre-pushフックの導入
+- core.hooksPath / init.templateDir の初期設定
+
+**使い方**:
+```
+@workspace /skill-git-initial-setup git init/clone時の保護を標準化したい
+```
+
+詳細: [skill-git-initial-setup/SKILL.md](skill-git-initial-setup/SKILL.md) | [日本語版](skill-git-initial-setup/references/SKILL.ja.md)
+
 ## 🚀 ワークフロー例
 
 ### 新しいSkillを作成する場合
@@ -134,7 +150,7 @@ python ~/.copilot/skills/skill-template-generator/scripts/generate_template.py
 1. **テンプレート生成** - `skill-template-generator`で雛形作成
 2. **執筆ガイド参照** - `skill-writing-guide`でベストプラクティス確認
 3. **内容作成** - 実際のSkill内容を記述
-4. **品質検証** - `skill-quality-validation`で55項目チェック
+4. **品質検証** - `skill-quality-validation`で64項目チェック
 5. **改善反映** - スコア80点以上を目指して修正
 6. **完成・公開**
 

--- a/skills/skill-git-initial-setup/SKILL.md
+++ b/skills/skill-git-initial-setup/SKILL.md
@@ -1,0 +1,479 @@
+---
+name: skill-git-initial-setup
+description: Default git setup to protect main after git init/clone. Use when standardizing repo bootstrap.
+author: RyoMurakami1983
+tags: [git, github, branch-protection, hooks, bootstrap]
+invocable: false
+version: 1.2.0
+---
+
+# Git Initial Setup for Main Protection
+
+Standardize main-branch protection for repositories created by git init/clone. Combine GitHub branch protection (Option A) with global hook defaults and local pre-commit/pre-push hooks (Option B) for defense in depth.
+
+## When to Use This Skill
+
+Use this skill when:
+- Defining default protections for new repos created by git init/clone
+- Rolling out global hook defaults across developer machines
+- Enforcing Pull Request (PR)-only merges for main in team repositories
+- Preventing accidental commits/pushes during release preparation
+- Adding local safeguards for private repos without protection rules
+- Auditing protection coverage before a major release
+
+## Related Skills
+
+- **`skill-git-japanese-practices`** - Git workflow and code review practices
+- **`skill-writing-guide`** - Skill documentation standards
+- **`skill-quality-validation`** - Validate skill quality
+
+---
+
+## Dependencies
+
+- Git 2.30+ (required)
+- Bash or PowerShell (for hook scripts)
+- GitHub account with repo admin access (for branch protection rules)
+
+## Core Principles
+
+1. **Defense in Depth** - Combine server-side and local protections (基礎と型)
+2. **Least Privilege** - Minimize who can push to main
+3. **Clear Workflow** - Make PR-only flow explicit (成長の複利)
+4. **Transparent Exceptions** - Document emergency paths (ニュートラル)
+5. **Automation First** - Reduce human error with repeatable scripts (継続は力)
+
+---
+
+## Pattern 1: Baseline Branch Protection Rule
+
+### Overview
+
+Create a minimal branch protection rule for main that requires pull requests.
+
+### Basic Example
+
+```txt
+# ✅ CORRECT - Require PRs for main
+Settings > Branches > Add rule
+Branch name pattern: main
+Enable: Require a pull request before merging
+
+# ❌ WRONG - Leaving main unprotected
+No branch protection rule set
+```
+
+### Intermediate Example
+
+- Require 1 approval
+- Require review from Code Owners
+- Require conversation resolution
+
+### Advanced Example
+
+- Include administrators
+- Require linear history
+- Restrict who can push to matching branches (empty list blocks direct pushes)
+
+Why: PR-only merges create traceability and reduce accidental changes.
+
+### When to Use
+
+| Scenario | Recommendation | Why |
+|----------|----------------|-----|
+| Small team repo | Basic rule | Fast protection with minimal overhead |
+| Larger teams | Intermediate | Adds review accountability |
+| Regulated environments | Advanced | Strong enforcement and auditability |
+
+**Values**: 基礎と型 / 継続は力
+
+---
+
+## Pattern 2: Pull Request Review Standards
+
+### Overview
+
+Define review requirements so main merges are intentional and traceable.
+
+### Basic Example
+
+- Require 1 approval
+- Assign default reviewers
+
+### Intermediate Example
+
+- Enable Code Owners
+- Dismiss stale approvals on new commits
+
+### Advanced Example
+
+- Require Code Owner review for protected paths
+- Require all conversations to be resolved
+
+### When to Use
+
+- You need accountability for every main merge
+- You want consistent review quality across teams
+
+**Values**: 成長の複利 / ニュートラル
+
+---
+
+## Pattern 3: Required Status Checks
+
+### Overview
+
+Gate merges on continuous integration (CI) checks so broken builds never land in main.
+
+### Basic Example
+
+- Require a single build check (e.g., `ci/build`)
+
+```yaml
+# ✅ CORRECT - Require build + test checks
+required_status_checks:
+  - ci/build
+  - ci/test
+
+# ❌ WRONG - No required checks
+required_status_checks: []
+```
+
+Why: Checks stop broken changes before they reach main.
+
+### Intermediate Example
+
+- Require tests + lint checks
+- Require branches to be up to date before merging
+
+### Advanced Example
+
+- Separate required checks by platform
+- Add release-specific checks for protected tags
+
+Why: Required checks keep main green and reduce rollback risk.
+
+### When to Use
+
+| Scenario | Recommendation | Why |
+|----------|----------------|-----|
+| Fast-moving repo | Basic | Keeps velocity without sacrificing quality |
+| Production services | Intermediate | Prevents regressions |
+| Multi-platform apps | Advanced | Ensures cross-platform stability |
+
+**Values**: 継続は力 / 基礎と型
+
+---
+
+## Pattern 4: Restrict Push Access and Admin Coverage
+
+### Overview
+
+Limit direct push access and ensure protections apply to administrators.
+
+### Basic Example
+
+- Enable "Include administrators"
+
+### Intermediate Example
+
+- Restrict who can push to matching branches
+- Allow only release automation accounts
+
+### Advanced Example
+
+- Document emergency bypass process
+- Require written approval for admin bypass
+
+### When to Use
+
+- You need strong guarantees that main is protected
+- You operate in regulated or audited environments
+
+**Values**: ニュートラル / 基礎と型
+
+---
+
+## Pattern 5: Local Pre-commit/Pre-push Hooks (Option B)
+
+### Overview
+
+Install local hooks to block commits and pushes to main before changes reach the remote.
+
+### Basic Example
+
+```bash
+# ✅ CORRECT - Install hooks for this repo
+./scripts/setup.sh
+
+# ❌ WRONG - Expecting hooks to run without installation
+git push origin main
+```
+
+This installs both pre-commit and pre-push hooks.
+
+### Intermediate Example
+
+Customize protected branches:
+
+```bash
+protected_branches=("main" "release")
+```
+
+### Advanced Example
+
+Use a shared Git template so new repos inherit the hook automatically.
+
+Why: Local hooks prevent mistakes before they reach the remote.
+
+### When to Use
+
+- Private repos without branch protection rules
+- Local safety net for new contributors
+- Block commits on main during release windows
+- Temporary protection before GitHub settings are configured
+
+**Values**: 継続は力 / 基礎と型
+
+---
+
+## Pattern 6: Git Init/Clone Defaults (Global Hooks)
+
+### Overview
+
+Configure global hook defaults so new repositories inherit protections automatically.
+
+### Basic Example
+
+Set a global hooks path (applies to existing repos too):
+
+```bash
+# ✅ CORRECT - Use a global hooks directory
+git config --global core.hooksPath "~/.githooks"
+```
+
+Why: core.hooksPath enforces hooks across repos on the same machine.
+
+### Intermediate Example
+
+Use an init template for git init (new repos only):
+
+```bash
+# ✅ CORRECT - Init template for new repos
+git config --global init.templateDir "~/.git-template"
+mkdir -p ~/.git-template/hooks
+cp scripts/pre-commit scripts/pre-push ~/.git-template/hooks/
+```
+
+Why: init.templateDir ensures new repos inherit hooks by default.
+
+### Advanced Example
+
+Provide a team bootstrap script that sets core.hooksPath and copies hooks once.
+
+```python
+# ✅ CORRECT - Bootstrap hooks for a workstation
+import shutil
+from pathlib import Path
+
+# Dependencies: Python 3.9+, Git 2.30+
+hooks_dir = Path.home() / ".githooks"
+hooks_dir.mkdir(parents=True, exist_ok=True)
+shutil.copy("scripts/pre-commit", hooks_dir / "pre-commit")
+shutil.copy("scripts/pre-push", hooks_dir / "pre-push")
+```
+
+Why: One-time bootstrap reduces manual setup errors.
+
+Optional automation tool (with dependency injection):
+
+```csharp
+// ✅ CORRECT - Inject hook settings for a bootstrap tool
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+services.Configure<HookOptions>(config.GetSection("Hooks"));
+services.AddSingleton<HookInstaller>();
+```
+
+### When to Use
+
+- You want git init/clone to pick up protections by default
+- You manage multiple repositories across the same workstation
+
+**Values**: 基礎と型 / 継続は力
+
+---
+
+## Pattern 7: Team Rollout Strategy
+
+### Overview
+
+Roll out protections with clear communication and onboarding steps.
+
+### Basic Example
+
+- Announce the PR-only policy
+- Share the setup scripts
+- Update onboarding docs
+
+### Intermediate Example
+
+- Add a PR checklist template
+- Record protection settings in a runbook
+
+### Advanced Example
+
+- Review protection settings quarterly
+- Audit repos for missing protections
+
+### When to Use
+
+- You manage multiple repositories
+- You need consistent protections across teams
+
+**Values**: 成長の複利 / 継続は力
+
+---
+
+## Pattern 8: Troubleshooting and Emergency Procedures
+
+### Overview
+
+Handle common failures without disabling protections permanently.
+
+### Basic Example
+
+- Hook not running: verify `core.hooksPath` and executable bit
+
+### Intermediate Example
+
+- Branch name mismatch: confirm rule matches `main`
+- CI checks missing: re-run or update required checks list
+
+### Advanced Example
+
+- Emergency hotfix: use a documented admin bypass with post-incident review
+- Local bypass: allow `git push --no-verify` only with explicit approval
+
+### When to Use
+
+- Protections block an urgent fix
+- Hook behavior differs across environments
+
+**Values**: ニュートラル / 温故知新
+
+---
+
+## Best Practices
+
+- Set global hook defaults before creating new repos
+- Use Pull Request (PR) reviews for all main merges
+- Set branch protection after the remote exists
+- Require at least one approval for main merges
+- Keep a written record of protection settings
+- Review protections after org or team changes
+- Document emergency bypass steps in a runbook
+
+Use core.hooksPath for all repos.  
+Set init.templateDir for new repos.  
+Avoid direct pushes to main.
+
+---
+
+## Common Pitfalls
+
+- Forgetting to include administrators in protection rules
+- Allowing direct pushes for convenience and never removing it
+- Relying only on local hooks for team-wide enforcement
+
+Fix: Enable "Include administrators" and document who can push.  
+Fix: Remove direct push permissions from main once PR flow is stable.  
+Fix: Add GitHub branch protection to enforce team-wide rules.
+
+---
+
+## Anti-Patterns
+
+- Disabling branch protection to make a quick change
+- Using `--no-verify` as a default workflow
+- Allowing unrestricted direct pushes to main
+
+---
+
+## FAQ
+
+**Q: Can I protect private repositories on the free plan?**  
+A: GitHub branch protection for private repos requires a paid plan. Use local hooks as a fallback.
+
+**Q: Will the PowerShell hook run automatically on Windows?**  
+A: Git for Windows runs hooks via Bash by default. Use the Bash hook or copy it into a shared hook path.
+
+**Q: Does git init automatically install these hooks?**  
+A: Only if you set core.hooksPath or init.templateDir globally. Otherwise, hooks are not installed by default.
+
+**Q: Does this block admins?**  
+A: Only if "Include administrators" is enabled in the branch protection rule.
+
+---
+
+## Quick Reference
+
+### Pattern Summary
+
+| Pattern | Focus | Use When |
+|---------|-------|----------|
+| 1 | Branch protection rule | You need PR-only merges |
+| 3 | Required status checks | You need build/test gates |
+| 5 | Local hooks | You need local safety nets |
+| 6 | Global defaults | You want git init/clone defaults |
+
+### Decision Table
+
+| Situation | Recommendation | Why |
+|-----------|----------------|-----|
+| New repo setup | Set core.hooksPath | Default protection everywhere |
+| Only new repos | Set init.templateDir | Avoid touching existing repos |
+| Private repo on free plan | Use local hooks | Server rules unavailable |
+| Team workflow | Enable PR-only merges | Traceable changes |
+
+```bash
+# Install hooks (pre-commit + pre-push) (macOS/Linux/Git Bash)
+./scripts/setup.sh
+
+# Install hooks (PowerShell)
+.\scripts\setup.ps1
+
+# Set global hooks path (all repos)
+git config --global core.hooksPath "~/.githooks"
+
+# Set init template (new repos only)
+git config --global init.templateDir "~/.git-template"
+
+# Verify current branch
+git branch --show-current
+```
+
+---
+
+## Resources
+
+- [GitHub Protected Branches](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches)
+- [Git Hooks Documentation](https://git-scm.com/docs/githooks)
+
+---
+
+## Changelog
+
+### Version 1.2.0 (2026-02-12)
+- Renamed skill to git initial setup scope
+- Added global hook defaults for git init/clone
+
+### Version 1.1.0 (2026-02-12)
+- Added pre-commit hook to block commits on main
+- Setup scripts install pre-commit + pre-push
+
+### Version 1.0.0 (2026-02-12)
+- Initial release
+- Branch protection rules + pre-push hook guidance
+- Bash and PowerShell scripts included

--- a/skills/skill-git-initial-setup/references/SKILL.ja.md
+++ b/skills/skill-git-initial-setup/references/SKILL.ja.md
@@ -1,0 +1,478 @@
+---
+name: skill-git-initial-setup
+description: git init/clone後のmain保護をデフォルト化する設定ガイド。初期セットアップで使う。
+author: RyoMurakami1983
+tags: [git, github, branch-protection, hooks, bootstrap]
+invocable: false
+version: 1.2.0
+---
+
+# Git初期セットアップ（main保護）
+
+git init/clone後のmain保護をデフォルト化するため、GitHubブランチ保護（Option A）とグローバルなフック設定、ローカルpre-commit/pre-push（Option B）を組み合わせます。
+
+## このスキルを使うとき
+
+以下の状況で活用してください：
+- git init/cloneの初期段階で保護をデフォルト化したい
+- グローバルフック設定をチームに展開したい
+- mainへのPull Request (PR)マージだけを強制したい
+- リリース前の誤コミット/誤プッシュを防止したい
+- privateリポジトリでローカル保護を補完したい
+- 大型リリース前に保護状況を監査したい
+
+## 関連スキル
+
+- **`skill-git-japanese-practices`** - Git運用とコードレビューの実践
+- **`skill-writing-guide`** - Skill執筆の標準
+- **`skill-quality-validation`** - Skill品質の検証
+
+---
+
+## 依存関係
+
+- Git 2.30+（必須）
+- BashまたはPowerShell（フックスクリプト用）
+- GitHubの管理権限（ブランチ保護設定用）
+
+## コア原則
+
+1. **多層防御** - サーバー側とローカル保護を組み合わせる（基礎と型）
+2. **最小権限** - mainへ直接プッシュできる人を最小化
+3. **明確なワークフロー** - PR運用を明文化（成長の複利）
+4. **例外の透明性** - 緊急時の手順を明記（ニュートラル）
+5. **自動化優先** - 反復スクリプトでヒューマンエラー低減（継続は力）
+
+---
+
+## パターン1: ベースラインのブランチ保護ルール
+
+### 概要
+
+mainに対する最小限の保護ルールを作成し、PR必須を徹底します。
+
+### 基本例
+
+```txt
+# ✅ CORRECT - mainのPR必須化
+Settings > Branches > Add rule
+Branch name pattern: main
+Enable: Require a pull request before merging
+
+# ❌ WRONG - mainを無保護のまま運用
+No branch protection rule set
+```
+
+### 中級例
+
+- 承認数を1に設定
+- Code Ownersレビューを必須化
+- 会話の解決を必須化
+
+### 上級例
+
+- 管理者も保護対象に含める
+- 線形履歴を必須化
+- 直接プッシュ可能ユーザーを制限（空欄で全ブロック）
+
+Why: PR運用で変更の追跡性と安全性を高める。
+
+### 使うとき
+
+| シナリオ | 推奨 | 理由 |
+|----------|------|------|
+| 小規模チーム | 基本 | 低コストで最小保護 |
+| 中〜大規模チーム | 中級 | レビュー責任を明確化 |
+| 監査・規制環境 | 上級 | 強い統制と追跡性 |
+
+**Values**: 基礎と型 / 継続は力
+
+---
+
+## パターン2: Pull Requestレビュー基準
+
+### 概要
+
+mainへのマージを意図的かつ追跡可能にするため、レビュー基準を整備します。
+
+### 基本例
+
+- 承認数を1に設定
+- デフォルトレビュアーを指定
+
+### 中級例
+
+- Code Ownersを有効化
+- 追加コミットで承認を無効化
+
+### 上級例
+
+- 保護パスにCode Ownerレビューを必須化
+- 全ての会話解決を必須化
+
+### 使うとき
+
+- mainのマージ責任を明確化したい
+- チーム全体でレビュー品質を揃えたい
+
+**Values**: 成長の複利 / ニュートラル
+
+---
+
+## パターン3: 必須ステータスチェック
+
+### 概要
+
+継続的インテグレーション（CI）チェックを必須化し、破損ビルドがmainに入るのを防ぎます。
+
+### 基本例
+
+- 1つのビルドチェックを必須化（例: `ci/build`）
+
+```yaml
+# ✅ CORRECT - ビルドとテストを必須化
+required_status_checks:
+  - ci/build
+  - ci/test
+
+# ❌ WRONG - 必須チェックなし
+required_status_checks: []
+```
+
+Why: 破損した変更をmainに入れない。
+
+### 中級例
+
+- テストとlintを必須化
+- ブランチの最新化を必須化
+
+### 上級例
+
+- プラットフォーム別の必須チェックを分離
+- リリース用タグに専用チェックを追加
+
+Why: mainの品質を継続的に担保する。
+
+### 使うとき
+
+| シナリオ | 推奨 | 理由 |
+|----------|------|------|
+| 高速開発チーム | 基本 | 速度と品質のバランス |
+| 本番サービス | 中級 | 回帰を防止 |
+| 複数プラットフォーム | 上級 | 安定性を担保 |
+
+**Values**: 継続は力 / 基礎と型
+
+---
+
+## パターン4: プッシュ権限の制限と管理者保護
+
+### 概要
+
+直接プッシュ権限を限定し、管理者にも保護を適用します。
+
+### 基本例
+
+- "Include administrators" を有効化
+
+### 中級例
+
+- 直接プッシュ可能ユーザーを制限
+- リリース自動化アカウントのみ許可
+
+### 上級例
+
+- 緊急バイパス手順を文書化
+- 管理者バイパス時に書面承認を必須化
+
+### 使うとき
+
+- main保護を強制したい
+- 監査対象の運用が必要
+
+**Values**: ニュートラル / 基礎と型
+
+---
+
+## パターン5: ローカルpre-commit/pre-pushフック（Option B）
+
+### 概要
+
+ローカルフックでmainへのコミットとプッシュをネットワーク前に遮断します。
+
+### 基本例
+
+```bash
+# ✅ CORRECT - 対象リポジトリにフックを導入
+./scripts/setup.sh
+
+# ❌ WRONG - 何もしないままmainへpush
+git push origin main
+```
+
+pre-commitとpre-pushの両方を導入します。
+
+### 中級例
+
+保護対象ブランチを拡張：
+
+```bash
+protected_branches=("main" "release")
+```
+
+### 上級例
+
+Gitテンプレートに組み込み、新規リポジトリで自動継承。
+
+Why: ネットワークに届く前に誤操作を止める。
+
+### 使うとき
+
+- privateリポジトリでの保護代替
+- 新メンバーの誤操作防止
+- mainへのコミットをローカルで止めたい
+- GitHub設定前の暫定保護
+
+**Values**: 継続は力 / 基礎と型
+
+---
+
+## パターン6: git init/cloneのデフォルト化（グローバルフック）
+
+### 概要
+
+グローバルなフック設定で、新規リポジトリに保護を自動適用します。
+
+### 基本例
+
+既存リポジトリにも効くグローバルフックパスを設定：
+
+```bash
+# ✅ CORRECT - 全リポジトリにフックを適用
+git config --global core.hooksPath "~/.githooks"
+```
+
+Why: 端末上の全リポジトリでフックが有効になる。
+
+### 中級例
+
+git init用のテンプレートを設定（新規のみ）：
+
+```bash
+# ✅ CORRECT - 新規リポジトリ向けのテンプレート
+git config --global init.templateDir "~/.git-template"
+mkdir -p ~/.git-template/hooks
+cp scripts/pre-commit scripts/pre-push ~/.git-template/hooks/
+```
+
+Why: git init時のデフォルト保護を実現する。
+
+### 上級例
+
+チーム用の初期化スクリプトでcore.hooksPathとコピーを一括実行。
+
+```python
+# ✅ CORRECT - 端末用ブートストラップ
+import shutil
+from pathlib import Path
+
+# Dependencies: Python 3.9+, Git 2.30+
+hooks_dir = Path.home() / ".githooks"
+hooks_dir.mkdir(parents=True, exist_ok=True)
+shutil.copy("scripts/pre-commit", hooks_dir / "pre-commit")
+shutil.copy("scripts/pre-push", hooks_dir / "pre-push")
+```
+
+Why: 初期セットアップの漏れを防ぐ。
+
+オプション: DIを使った自動化ツール例
+
+```csharp
+// ✅ CORRECT - フック設定をDIで注入
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+services.Configure<HookOptions>(config.GetSection("Hooks"));
+services.AddSingleton<HookInstaller>();
+```
+
+### 使うとき
+
+- git init/clone時にデフォルトで保護したい
+- 同一端末で複数リポジトリを扱う
+
+**Values**: 基礎と型 / 継続は力
+
+---
+
+## パターン7: チーム展開戦略
+
+### 概要
+
+コミュニケーションとオンボーディングを含めて保護を展開します。
+
+### 基本例
+
+- PR運用の告知
+- セットアップ手順を共有
+- オンボーディング資料を更新
+
+### 中級例
+
+- PRチェックリストを導入
+- 運用手順書に設定を記録
+
+### 上級例
+
+- 四半期ごとに保護設定をレビュー
+- リポジトリ単位で監査
+
+### 使うとき
+
+- 複数リポジトリを管理している
+- チーム間で統一した運用が必要
+
+**Values**: 成長の複利 / 継続は力
+
+---
+
+## パターン8: トラブルシューティングと緊急対応
+
+### 概要
+
+保護を無効化せずに問題を解消し、緊急対応を安全に行います。
+
+### 基本例
+
+- フックが動かない: `core.hooksPath` と実行権限を確認
+
+### 中級例
+
+- ルールが効かない: `main` との一致を確認
+- 必須チェック未登録: 必須チェック一覧を更新
+
+### 上級例
+
+- 緊急修正: 管理者バイパス + 事後レビュー
+- ローカル回避: `git push --no-verify` は明示承認のみ
+
+### 使うとき
+
+- 緊急修正で保護が障害になった
+- 環境ごとに挙動が違う
+
+**Values**: ニュートラル / 温故知新
+
+---
+
+## ベストプラクティス
+
+- 先にグローバルフックを設定してから新規リポジトリを作成
+- リモート作成後にGitHub保護を有効化
+- mainマージに最低1承認を必須化
+- 保護設定を運用ドキュメントに記録
+- 組織変更後に保護設定を再確認
+- 緊急バイパス手順を運用書に明記
+
+core.hooksPath を全リポジトリに適用する。  
+init.templateDir を新規リポジトリに適用する。  
+mainへの直接プッシュを避ける。
+
+---
+
+## よくある落とし穴
+
+- 管理者保護のチェック漏れ
+- 便利だからと直接プッシュを残し続ける
+- ローカルフックだけで全体保護を期待する
+
+Fix: "Include administrators" を必ず有効化し、権限を記録する。  
+Fix: mainの直接プッシュ権限を段階的に撤廃する。  
+Fix: GitHubの保護ルールでチーム全体を強制する。
+
+---
+
+## アンチパターン
+
+- 早く直したいから保護を一時解除する
+- `--no-verify`を常用フローにする
+- mainへの直接プッシュを自由化する
+
+---
+
+## FAQ
+
+**Q: 無料プランのprivateリポジトリでも保護できますか？**  
+A: GitHubのブランチ保護は有料プランが必要です。ローカルフックで代替してください。
+
+**Q: WindowsでPowerShellフックは自動実行されますか？**  
+A: Git for WindowsはBashでフックを実行します。Bash版を使うか共有フックパスに配置してください。
+
+**Q: git initで自動的にフックは入りますか？**  
+A: core.hooksPath または init.templateDir をグローバル設定した場合のみ自動適用されます。
+
+**Q: 管理者もブロックされますか？**  
+A: ルールで"Include administrators"を有効化した場合のみ対象になります。
+
+---
+
+## クイックリファレンス
+
+### パターン要約
+
+| パターン | 目的 | 使うとき |
+|---------|------|----------|
+| 1 | ブランチ保護ルール | PR運用を徹底したい |
+| 3 | 必須ステータスチェック | ビルド/テストを必須化 |
+| 5 | ローカルフック | ローカル安全策が必要 |
+| 6 | グローバルデフォルト | git init/cloneを標準化 |
+
+### 判断テーブル
+
+| 状況 | 推奨 | 理由 |
+|------|------|------|
+| 新規リポジトリ | core.hooksPath設定 | 全体デフォルト化 |
+| 新規のみ適用 | init.templateDir設定 | 既存に影響なし |
+| private/無料プラン | ローカルフック | サーバー保護不可 |
+| チーム運用 | PR必須化 | 変更の追跡性向上 |
+
+```bash
+# フック導入（pre-commit + pre-push）（macOS/Linux/Git Bash）
+./scripts/setup.sh
+
+# フック導入（PowerShell）
+.\scripts\setup.ps1
+
+# グローバルフック設定（全リポジトリ）
+git config --global core.hooksPath "~/.githooks"
+
+# initテンプレート設定（新規のみ）
+git config --global init.templateDir "~/.git-template"
+
+# 現在のブランチ確認
+git branch --show-current
+```
+
+---
+
+## リソース
+
+- [GitHub Protected Branches](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches)
+- [Git Hooks Documentation](https://git-scm.com/docs/githooks)
+
+---
+
+## 変更履歴
+
+### Version 1.2.0 (2026-02-12)
+- skill名をgit初期セットアップに変更
+- git init/clone向けのグローバルフック設定を追加
+
+### Version 1.1.0 (2026-02-12)
+- mainへのコミットを止めるpre-commitを追加
+- セットアップでpre-commit + pre-pushを導入
+
+### Version 1.0.0 (2026-02-12)
+- 初版リリース
+- ブランチ保護ルール + pre-pushフックを整理
+- Bash/PowerShellスクリプト同梱

--- a/skills/skill-git-initial-setup/scripts/pre-commit
+++ b/skills/skill-git-initial-setup/scripts/pre-commit
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Prevent direct commits to protected branches.
+
+set -euo pipefail
+
+protected_branches=("main")
+current_branch="$(git symbolic-ref --short HEAD 2>/dev/null || echo '')"
+
+if [ -z "$current_branch" ]; then
+    exit 0
+fi
+
+for branch in "${protected_branches[@]}"; do
+    if [ "$current_branch" = "$branch" ]; then
+        echo ""
+        echo "❌ ERROR: Direct commits to '$branch' are not allowed."
+        echo ""
+        echo "Use a feature branch instead:"
+        echo "  1. git checkout -b feature/your-change"
+        echo ""
+        exit 1
+    fi
+done
+
+exit 0

--- a/skills/skill-git-initial-setup/scripts/pre-commit.ps1
+++ b/skills/skill-git-initial-setup/scripts/pre-commit.ps1
@@ -1,0 +1,20 @@
+# Prevent direct commits to protected branches (PowerShell version).
+
+$protectedBranches = @('main')
+$currentBranch = (git symbolic-ref --short HEAD 2>$null).Trim()
+
+if (-not $currentBranch) {
+    exit 0
+}
+
+if ($protectedBranches -contains $currentBranch) {
+    Write-Host ""
+    Write-Host "❌ ERROR: Direct commits to '$currentBranch' are not allowed." -ForegroundColor Red
+    Write-Host ""
+    Write-Host "Use a feature branch instead:" -ForegroundColor Yellow
+    Write-Host "  1. git checkout -b feature/your-change"
+    Write-Host ""
+    exit 1
+}
+
+exit 0

--- a/skills/skill-git-initial-setup/scripts/pre-push
+++ b/skills/skill-git-initial-setup/scripts/pre-push
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Prevent direct pushes to protected branches.
+
+set -euo pipefail
+
+protected_branches=("main")
+current_branch="$(git symbolic-ref --short HEAD 2>/dev/null || echo '')"
+
+if [ -z "$current_branch" ]; then
+    exit 0
+fi
+
+for branch in "${protected_branches[@]}"; do
+    if [ "$current_branch" = "$branch" ]; then
+        echo ""
+        echo "❌ ERROR: Direct push to '$branch' is not allowed."
+        echo ""
+        echo "Use a feature branch and open a Pull Request:"
+        echo "  1. git checkout -b feature/your-change"
+        echo "  2. git push origin feature/your-change"
+        echo ""
+        exit 1
+    fi
+done
+
+exit 0

--- a/skills/skill-git-initial-setup/scripts/pre-push.ps1
+++ b/skills/skill-git-initial-setup/scripts/pre-push.ps1
@@ -1,0 +1,21 @@
+# Prevent direct pushes to protected branches (PowerShell version).
+
+$protectedBranches = @('main')
+$currentBranch = (git symbolic-ref --short HEAD 2>$null).Trim()
+
+if (-not $currentBranch) {
+    exit 0
+}
+
+if ($protectedBranches -contains $currentBranch) {
+    Write-Host "" 
+    Write-Host "❌ ERROR: Direct push to '$currentBranch' is not allowed." -ForegroundColor Red
+    Write-Host "" 
+    Write-Host "Use a feature branch and open a Pull Request:" -ForegroundColor Yellow
+    Write-Host "  1. git checkout -b feature/your-change"
+    Write-Host "  2. git push origin feature/your-change"
+    Write-Host "" 
+    exit 1
+}
+
+exit 0

--- a/skills/skill-git-initial-setup/scripts/setup.ps1
+++ b/skills/skill-git-initial-setup/scripts/setup.ps1
@@ -1,0 +1,18 @@
+# Install pre-commit and pre-push hooks into the current repository (PowerShell).
+
+$repoRoot = git rev-parse --show-toplevel 2>$null
+if (-not $repoRoot) {
+    Write-Error "Not inside a git repository."
+    exit 1
+}
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$hookDir = Join-Path $repoRoot ".git\hooks"
+
+New-Item -ItemType Directory -Force -Path $hookDir | Out-Null
+Copy-Item (Join-Path $scriptDir "pre-commit") (Join-Path $hookDir "pre-commit") -Force
+Copy-Item (Join-Path $scriptDir "pre-commit.ps1") (Join-Path $hookDir "pre-commit.ps1") -Force
+Copy-Item (Join-Path $scriptDir "pre-push") (Join-Path $hookDir "pre-push") -Force
+Copy-Item (Join-Path $scriptDir "pre-push.ps1") (Join-Path $hookDir "pre-push.ps1") -Force
+
+Write-Host "✅ Installed pre-commit and pre-push hooks to $hookDir" -ForegroundColor Green

--- a/skills/skill-git-initial-setup/scripts/setup.sh
+++ b/skills/skill-git-initial-setup/scripts/setup.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Install pre-commit and pre-push hooks into the current repository.
+
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null || true)
+if [ -z "$repo_root" ]; then
+    echo "❌ Not inside a git repository."
+    exit 1
+fi
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+hook_dir="$repo_root/.git/hooks"
+
+mkdir -p "$hook_dir"
+cp "$script_dir/pre-commit" "$hook_dir/pre-commit"
+cp "$script_dir/pre-push" "$hook_dir/pre-push"
+chmod +x "$hook_dir/pre-commit" "$hook_dir/pre-push"
+
+echo "✅ Installed pre-commit and pre-push hooks to $hook_dir"

--- a/skills/skill-git-japanese-practices/references/SKILL.ja.md
+++ b/skills/skill-git-japanese-practices/references/SKILL.ja.md
@@ -14,7 +14,7 @@ version: 1.0.0
 ## 関連スキル
 
 - **`skill-writing-guide`** - Skill執筆のベストプラクティス
-- **`skill-quality-validation`** - 55項目品質検証
+- **`skill-quality-validation`** - 64項目品質検証
 - **`skill-template-generator`** - テンプレート自動生成
 - **`skill-revision-guide`** - 修正・バージョン管理
 

--- a/skills/skill-quality-validation/references/SKILL.ja.md
+++ b/skills/skill-quality-validation/references/SKILL.ja.md
@@ -1,340 +1,586 @@
-# Skill品質評価チェックリスト
+---
+name: skill-quality-validation
+description: GitHub Copilot agentスキルの品質を検証する。SKILL.mdのレビュー時に使用する。
+author: RyoMurakami1983
+tags: [copilot, agent-skills, quality, validation, testing]
+invocable: false
+---
 
-**バージョン**: 1.0.0  
-**作成日**: 2026-02-07  
-**目的**: Skill執筆の品質を定量的に評価し、高品質基準を満たすことを保証する
+# Skill品質検証
+
+GitHub Copilot agentスキル向けの64項目チェックリスト、スコアリング、開発哲学統合を備えた包括的品質評価システムです。
+
+## このスキルを使うとき
+
+以下の状況で活用してください：
+- 完成したSKILL.mdを公開前にレビューして品質保証したい
+- 公式の64項目基準に対してスキル品質を評価したい
+- スコアと改善提案を含む詳細レポートを作成したい
+- ドキュメント構造や内容の問題を特定したい
+- GitHub Copilot/Claude仕様への準拠を検証したい
+- コード例を含むピアレビューを徹底したい
 
 ---
 
-## 📋 使い方
+## 関連スキル
 
-このチェックリストは以下の4つのカテゴリで構成されています：
-
-1. **構造チェック（10項目）** - ファイル構造とセクション配置
-2. **内容チェック（20項目）** - コンテンツの完全性と正確性
-3. **コード品質チェック（15項目）** - コード例の品質
-4. **言語・表現チェック（10項目）** - 読みやすさと一貫性
-
-**評価方法**:
-- 各項目を Yes/No で評価
-- ✅ Yes = 1点、❌ No = 0点
-- **合格ライン**: 各カテゴリ80%以上、総合85%以上
+- **`skill-writing-guide`** - Skill執筆のベストプラクティス
+- **`skill-template-generator`** - Skillテンプレート生成
+- **`skill-revision-guide`** - 検証結果に基づく修正
 
 ---
 
-## 1. 構造チェック（10項目）
+## コア原則
 
-**基準**: Skillの物理的構造とセクション配置が標準に準拠しているか
-
-| # | チェック項目 | Yes/No | 備考 |
-|---|------------|--------|------|
-| 1.1 | SKILL.md のみで構成され、追加ファイルがない | [ ] | |
-| 1.2 | YAML frontmatter が存在し、name/description/invocable を含む | [ ] | |
-| 1.3 | frontmatter の name がフォルダ名と一致（kebab-case） | [ ] | |
-| 1.4 | description が100文字以内で問題解決にフォーカス | [ ] | |
-| 1.5 | "When to Use This Skill" が最初のH2セクションである | [ ] | |
-| 1.6 | "Core Principles" または "The Philosophy" セクションが存在 | [ ] | |
-| 1.7 | 7-10個のパターンセクション（H2）が存在 | [ ] | |
-| 1.8 | "Common Pitfalls" セクションが存在 | [ ] | |
-| 1.9 | "Anti-Patterns" セクションが存在 | [ ] | |
-| 1.10 | "Quick Reference" または "Decision Tree" セクションが存在 | [ ] | |
-
-**スコア**: _____ / 10 = _____%
-
-**合格ライン**: 8/10 (80%) 以上
+1. **定量評価** - 64項目チェックリストで客観評価
+2. **カテゴリ別スコア** - Structure(14), Content(23), Code Quality(16), Language(11)
+3. **明確な合格基準** - 各カテゴリ80%、全体80%（51/64）
+4. **実行可能なフィードバック** - 具体的な失敗と改善提案
+5. **継続的改善** - 90%+を目標に反復
+6. **哲学の統合** - 開発Valuesと整合（基礎と型、成長の複利、温故知新、継続は力、ニュートラル）
 
 ---
 
-## 2. 内容チェック（20項目）
+## パターン1: 品質チェックの実行
 
-**基準**: コンテンツの完全性、明確性、実用性
+### 概要
 
-### 2.1 "When to Use" セクション（4項目）
+64項目チェックリストで4カテゴリの品質を評価し、ファイル長最適化、references/構造、日英対応、開発哲学の整合も確認します。
 
-| # | チェック項目 | Yes/No | 備考 |
-|---|------------|--------|------|
-| 2.1.1 | 5-8個の具体的なシナリオがリストされている | [ ] | |
-| 2.1.2 | 各シナリオが動詞で始まる（Designing, Implementing, etc.） | [ ] | |
-| 2.1.3 | 各シナリオが50-100文字の範囲内 | [ ] | |
-| 2.1.4 | 抽象的な表現がない（"good code", "quality software" 等） | [ ] | |
+### 基本例
 
-### 2.2 Core Principles セクション（3項目）
+**クイックチェック**（手動）:
+1. SKILL.mdを開く
+2. YAML frontmatterに必須項目があるか確認
+3. "When to Use This Skill" が最初のH2か確認
+4. パターン数を数える（7-10）
+5. Common PitfallsとAnti-Patternsが存在するか確認
 
-| # | チェック項目 | Yes/No | 備考 |
-|---|------------|--------|------|
-| 2.2.1 | 3-5個の原則がリストされている | [ ] | |
-| 2.2.2 | 各原則が太字名 + 簡潔な説明（30-50文字）の形式 | [ ] | |
-| 2.2.3 | 各原則が独立して理解可能 | [ ] | |
+### 使うとき
 
-### 2.3 パターンセクション（6項目）
+| シナリオ | アプローチ | 理由 |
+|----------|------------|------|
+| 公開前レビュー | 64項目の全チェック | 品質基準を保証 |
+| 迅速確認 | 10項目の構造チェック | 執筆中の早期フィードバック |
+| ピアレビュー | 内容 + コードチェック | 中身に集中 |
+| 修正後 | 以前の失敗項目を再確認 | 修正の確認 |
 
-| # | チェック項目 | Yes/No | 備考 |
-|---|------------|--------|------|
-| 2.3.1 | 各パターンに "Overview" サブセクションがある | [ ] | |
-| 2.3.2 | 各パターンに最低3段階の例（Basic/Intermediate/Advanced）がある | [ ] | |
-| 2.3.3 | 各パターンに "When to Use" ガイダンスがある | [ ] | |
-| 2.3.4 | パターン間で重複がない（各パターンが独自の価値を提供） | [ ] | |
-| 2.3.5 | パターンが論理的な順序で配置されている | [ ] | |
-| 2.3.6 | 少なくとも1つのパターンに比較表が含まれている | [ ] | |
+### 設定例
 
-### 2.4 Problem-Solution構造（2項目）
+**構造化チェックリスト**:
 
-| # | チェック項目 | Yes/No | 備考 |
-|---|------------|--------|------|
-| 2.4.1 | ❌/✅ マーカーで悪い例と良い例のペアが提示されている | [ ] | |
-| 2.4.2 | "Why"（なぜこのアプローチが良いか/悪いか）が説明されている | [ ] | |
+```markdown
+## 1. Structure Check (11 items)
 
-### 2.5 Anti-Patterns & Pitfalls（3項目）
+- [x] 1.1 SKILL.md only, no additional files
+- [x] 1.2 YAML frontmatter with name/description/invocable
+- [x] 1.3 Name matches directory (kebab-case)
+- [x] 1.4 Description ≤ 100 chars, problem-focused
+- [x] 1.5 "When to Use This Skill" is first H2 section
+- [x] 1.6 "Core Principles" section exists
+- [ ] 1.7 7-10 pattern sections (H2)          ← FAIL: Only 3 patterns
+- [x] 1.8 "Common Pitfalls" section exists
+- [x] 1.9 "Anti-Patterns" section exists
+- [x] 1.10 "Quick Reference" or "Decision Tree" exists
+- [x] 1.11 SKILL.md file ≤500 lines (Claude/GitHub Copilot recommendation)
 
-| # | チェック項目 | Yes/No | 備考 |
-|---|------------|--------|------|
-| 2.5.1 | Anti-Patternsがアーキテクチャレベルの問題を扱っている | [ ] | |
-| 2.5.2 | Common Pitfallsが実装レベルのミスを扱っている | [ ] | |
-| 2.5.3 | 各Anti-Pattern/Pitfallに修正方法が提示されている | [ ] | |
-
-### 2.6 Quick Reference（2項目）
-
-| # | チェック項目 | Yes/No | 備考 |
-|---|------------|--------|------|
-| 2.6.1 | 意思決定支援の表またはフローチャートが含まれている | [ ] | |
-| 2.6.2 | スキャンのみで主要なパターンが理解できる | [ ] | |
-
-**スコア**: _____ / 20 = _____%
-
-**合格ライン**: 16/20 (80%) 以上
+**Score**: 9/11 = 82% ✅ PASS
+```
 
 ---
 
-## 3. コード品質チェック（15項目）
+## パターン2: 構造検証（14項目）
 
-**基準**: コード例の正確性、実用性、一貫性
+### 概要
 
-### 3.1 コンパイル可能性（3項目）
+ファイル構造、セクション順序、frontmatter準拠、行数最適化、references/構成、日英対応を検証します。
 
-| # | チェック項目 | Yes/No | 備考 |
-|---|------------|--------|------|
-| 3.1.1 | 全コード例がコンパイル可能（または明示的に疑似コードと記載） | [ ] | |
-| 3.1.2 | 必要なusing文が含まれている | [ ] | |
-| 3.1.3 | 依存関係（NuGetパッケージ）が明記されている | [ ] | |
+### 基本例
 
-### 3.2 段階的な進化（3項目）
+**14項目の構造チェック**:
 
-| # | チェック項目 | Yes/No | 備考 |
-|---|------------|--------|------|
-| 3.2.1 | Simple → Intermediate → Advanced の順でコードが進化 | [ ] | |
-| 3.2.2 | 各段階で「なぜこの進化が必要か」が説明されている | [ ] | |
-| 3.2.3 | Advanced例がプロダクションレディ（エラーハンドリング等） | [ ] | |
+1. **Single File**: SKILL.mdのみ（README.md, examples.md等は不可）
+2. **YAML Frontmatter**: name/description/invocableを含む
+3. **Name Consistency**: nameがフォルダ名と一致（kebab-case）
+4. **Description Length**: 100文字以内、問題解決に焦点
+5. **When to Use Position**: タイトル直後の最初のH2
+6. **Core Principles**: セクションが存在
+7. **Pattern Count**: 7-10個のH2パターン
+8. **Common Pitfalls**: セクションが存在
+9. **Anti-Patterns**: セクションが存在
+10. **Quick Reference**: セクションまたはDecision Treeが存在
+11. **File Length Optimization**: ≤500行推奨、≤550行は警告
+12. **References Directory**: 500行超ならreferences/必須
+13. **Japanese Version**（ボーナス）: `references/SKILL.ja.md`が存在
+14. **References Validity**: references/内の命名規則を検証
 
-### 3.3 マーカーとコメント（4項目）
+### 使うとき
 
-| # | チェック項目 | Yes/No | 備考 |
-|---|------------|--------|------|
-| 3.3.1 | ✅/❌ マーカーが一貫して使用されている | [ ] | |
-| 3.3.2 | インラインコメントが "WHY" を説明（"HOW" ではない） | [ ] | |
-| 3.3.3 | コメントが簡潔（1行あたり50文字以内） | [ ] | |
-| 3.3.4 | 冗長なコメントがない（コードで明らかなことを説明しない） | [ ] | |
+構造検証は次のタイミングで実施：
+- **執筆前**: 骨格が正しいか確認
+- **大規模リファクタ後**: 構造の整合性を確認
+- **ピアレビュー**: 構造の準拠を素早く確認
 
-### 3.4 完全性（5項目）
+**合格基準**: 11/14 (79%) 以上
 
-| # | チェック項目 | Yes/No | 備考 |
-|---|------------|--------|------|
-| 3.4.1 | DI設定例が含まれている（該当する場合） | [ ] | |
-| 3.4.2 | 設定ファイル例が含まれている（appsettings.json等、該当する場合） | [ ] | |
-| 3.4.3 | エラーハンドリング例が含まれている | [ ] | |
-| 3.4.4 | 非同期処理が正しく実装されている（async/await, CancellationToken等） | [ ] | |
-| 3.4.5 | リソース管理が適切（using, Dispose等） | [ ] | |
+### 設定例
 
-**スコア**: _____ / 15 = _____%
+**詳細ルール**:
 
-**合格ライン**: 12/15 (80%) 以上
-
----
-
-## 4. 言語・表現チェック（10項目）
-
-**基準**: 読みやすさ、一貫性、明確性
-
-### 4.1 文章スタイル（4項目）
-
-| # | チェック項目 | Yes/No | 備考 |
-|---|------------|--------|------|
-| 4.1.1 | 能動態で書かれている（受動態が最小限） | [ ] | |
-| 4.1.2 | 一文が短い（英語: 20単語以内、日本語: 50文字以内） | [ ] | |
-| 4.1.3 | 命令形を使用（"Use", "Implement" vs "You should use"） | [ ] | |
-| 4.1.4 | 曖昧な表現がない（"may", "might", "possibly" の多用なし） | [ ] | |
-
-### 4.2 用語の一貫性（3項目）
-
-| # | チェック項目 | Yes/No | 備考 |
-|---|------------|--------|------|
-| 4.2.1 | 同じ概念に同じ用語を使用（類義語の混在なし） | [ ] | |
-| 4.2.2 | 専門用語が初出時に定義されている | [ ] | |
-| 4.2.3 | 略語が初出時に展開されている（例: DDD → Domain-Driven Design） | [ ] | |
-
-### 4.3 スキャン可能性（3項目）
-
-| # | チェック項目 | Yes/No | 備考 |
-|---|------------|--------|------|
-| 4.3.1 | 見出しのみで文書構造が理解できる | [ ] | |
-| 4.3.2 | 表が見やすい（3-6列、5-10行） | [ ] | |
-| 4.3.3 | 重要な情報が太字や表でハイライトされている | [ ] | |
-
-**スコア**: _____ / 10 = _____%
-
-**合格ライン**: 8/10 (80%) 以上
+```yaml
+# Structure Check Configuration
+checks:
+  1.1_single_file:
+    rule: "Count of *.md files in skill directory == 1"
+    allow_exceptions: ["references/SKILL.ja.md", "references/*.md", "CHANGELOG.md"]
+  
+  1.4_description_length:
+    rule: "len(frontmatter['description']) <= 100"
+    severity: "warning"  # Over 100 is warning, over 150 is failure
+  
+  1.7_pattern_count:
+    rule: "7 <= pattern_count <= 10"
+    count_method: "regex: ^## Pattern \\d+:"
+  
+  1.11_file_length_optimization:
+    rule: |
+      if line_count <= 500: PASS
+      elif line_count <= 550: PASS with WARNING (+10% tolerance)
+      else: FAIL (require references/ structure)
+    recommended: 500
+    tolerance: 550
+  
+  1.12_references_directory:
+    rule: "If line_count > 500, check references/ directory exists"
+    valid_files: ["anti-patterns.md", "advanced-examples.md", "configuration.md", "SKILL.ja.md"]
+    required_count: ">= 1"
+  
+  1.13_japanese_version:
+    rule: "Check for references/SKILL.ja.md"
+    bonus: true  # +1 bonus point if exists
+    required: false
+  
+  1.14_references_validity:
+    rule: "If references/ exists, validate all files are *.md"
+    severity: "error"
+```
 
 ---
 
-## 総合評価
+## パターン3: 内容検証（23項目）
 
-### スコアサマリー
+### 概要
 
-| カテゴリ | 獲得点数 | 満点 | 達成率 | 合格ライン | 結果 |
-|---------|---------|------|--------|-----------|------|
-| 1. 構造チェック | _____ | 10 | ____% | 80% | [ ] 合格 / [ ] 不合格 |
-| 2. 内容チェック | _____ | 20 | ____% | 80% | [ ] 合格 / [ ] 不合格 |
-| 3. コード品質 | _____ | 15 | ____% | 80% | [ ] 合格 / [ ] 不合格 |
-| 4. 言語・表現 | _____ | 10 | ____% | 80% | [ ] 合格 / [ ] 不合格 |
-| **総合** | **_____** | **55** | **____%** | **85%** | [ ] **合格** / [ ] **不合格** |
+"When to Use"、Core Principles、Patterns、Problem-Solution構造、Values統合、Why説明の有無を検証します。
 
-### 総合判定基準
+### 基本例
 
-**✅ 合格**:
-- 各カテゴリが80%以上
-- 総合が85%以上（47/55点以上）
+**主要チェック項目**:
 
-**⚠️ 条件付き合格**:
-- 総合が80-84%（44-46/55点）
-- 改善推奨項目をリストアップ
+- **When to Use**（4項目）:
+  - 5-8個の具体的シナリオ
+  - 各項目が動詞で開始
+  - 50-100文字以内
+  - 抽象表現がない（"good code"等）
 
-**❌ 不合格**:
-- いずれかのカテゴリが80%未満
-- または総合が80%未満（44/55点未満）
-- 再執筆または大幅修正が必要
+- **Patterns**（6項目）:
+  - Overviewがある
+  - Basic/Intermediate/Advancedの3段階
+  - "When to Use"がある
+  - パターン間の重複がない
 
----
+- **Core Principles**（2項目）:
+  - Values統合（基礎と型、成長の複利など）
+  - スキル目的と整合
 
-## 改善アクションプラン
+- **Pattern Quality**（2項目）:
+  - Why説明がある
+  - Progressive Disclosureが守られている
 
-### 不合格項目の記録
+### 使うとき
 
-**構造チェック不合格項目**:
-- [ ] 項目番号: _____ - 問題: _____ - 対策: _____
+内容検証は以下に必須：
+- **実用性の評価**: 実行可能なガイダンスか
+- **完全性の確認**: 必須サブセクションの有無
+- **明確性の確認**: 具体的なシナリオか
 
-**内容チェック不合格項目**:
-- [ ] 項目番号: _____ - 問題: _____ - 対策: _____
+**合格基準**: 18/23 (78%) 以上
 
-**コード品質不合格項目**:
-- [ ] 項目番号: _____ - 問題: _____ - 対策: _____
+### 設定例
 
-**言語・表現不合格項目**:
-- [ ] 項目番号: _____ - 問題: _____ - 対策: _____
+**検証ルール**:
 
-### 優先順位付け
+```python
+# ✅ CORRECT - Validate "When to Use" scenarios
+scenarios = skill.get_when_to_use_scenarios()
 
-**Critical（即座に修正必須）**:
-1. _____
-2. _____
+# Check 2.1.1: Count (5-8 scenarios)
+if 5 <= len(scenarios) <= 8:
+    pass  # ✅ Valid
 
-**High（次回レビュー前に修正）**:
-1. _____
-2. _____
+# Check 2.1.2: Start with verb
+if all(scenario.split()[0].lower() in ACTION_VERBS for scenario in scenarios):
+    pass  # ✅ Valid
 
-**Medium（改善推奨）**:
-1. _____
-2. _____
+# Check 2.1.3: Length (50-100 chars)
+if all(50 <= len(s) <= 100 for s in scenarios):
+    pass  # ✅ Valid
 
-**Low（Nice to Have）**:
-1. _____
-2. _____
+# Check 2.1.4: No abstract phrases
+if not any(phrase in s.lower() for s in scenarios for phrase in ABSTRACT_PHRASES):
+    pass  # ✅ Valid
 
----
+# ✅ NEW - Validate Core Principles - Values integration
+core_principles = skill.get_core_principles()
+DEVELOPMENT_VALUES = ['基礎と型', '成長の複利', '温故知新', '継続は力', 'ニュートラル']
 
-## ベンチマーク比較
+# Check 2.2.1: Values integration (bonus)
+values_found = any(value in core_principles for value in DEVELOPMENT_VALUES)
+if values_found:
+    bonus_points += 1  # +1 bonus point
 
-### 参照Skill（高品質の例）
+# ✅ NEW - Validate Pattern Quality - Why explanations
+advanced_patterns = skill.get_patterns(level='Advanced')
 
-以下のSkillは全てこのチェックリストで95%以上を達成：
+# Check 2.2.2: Why explanations in complex patterns
+why_count = sum(1 for p in advanced_patterns if 'why' in p.lower() or '理由' in p)
+if why_count >= len(advanced_patterns) * 0.5:  # At least 50%
+    pass  # ✅ Valid
 
-| Skill名 | 構造 | 内容 | コード | 言語 | 総合 |
-|---------|------|------|--------|------|------|
-| csharp-api-design | 10/10 | 19/20 | 15/15 | 9/10 | 53/55 (96%) |
-| efcore-patterns | 10/10 | 20/20 | 14/15 | 10/10 | 54/55 (98%) |
-| csharp-concurrency-patterns | 10/10 | 19/20 | 15/15 | 9/10 | 53/55 (96%) |
-| database-performance | 10/10 | 20/20 | 14/15 | 10/10 | 54/55 (98%) |
+# ✅ NEW - Validate Progressive Disclosure
+if skill.line_count > 500:
+    # Check 2.2.3: Progressive Disclosure strategy
+    has_references_dir = Path('references/').exists()
+    advanced_in_references = any(f.name.startswith('advanced') for f in Path('references/').glob('*.md'))
+    if has_references_dir and advanced_in_references:
+        pass  # ✅ Valid
+```
 
-**あなたのSkillがこれらのベンチマークと同等なら、高品質と判定できます。**
-
----
-
-## レビューサイン
-
-**レビュアー**: _____________________  
-**レビュー日**: _____________________  
-**総合判定**: [ ] 合格 / [ ] 条件付き合格 / [ ] 不合格
-
-**コメント**:
-_____________________________________________________________________
-_____________________________________________________________________
-_____________________________________________________________________
-
-**次のアクション**:
-- [ ] 即座に公開可能
-- [ ] 軽微な修正後に公開
-- [ ] 改善後に再レビュー
-- [ ] 大幅な再執筆が必要
+> 📚 **完全な実装**: `references/validation-examples.md` を参照  
+> 📚 **失敗例**: `references/anti-patterns.md` を参照
 
 ---
 
-## 付録: よくある不合格理由と対策
+## パターン4: コード品質検証（16項目）
 
-### 1. 構造チェック不合格
+### 概要
 
-**よくある問題**:
-- "When to Use" が2番目以降のセクション
-- パターンが5個以下または15個以上
+コンパイル可能性、段階的複雑度、マーカー一貫性、本番品質、コード例の長さ制限を検証します。
 
-**対策**:
-- SKILL_TEMPLATE.md の構造に厳密に従う
-- パターン数を7-10個に調整
+### 基本例
 
-### 2. 内容チェック不合格
+**主要チェック項目**:
 
-**よくある問題**:
-- "When to Use" のシナリオが抽象的
-- Problem-Solution構造がない
+- **Compilability**（3項目）: コードがコンパイル可能、usingあり、依存関係の明記
+- **Progression**（3項目）: Simple → Advancedの順序、各段階を説明
+- **Markers**（4項目）: ✅/❌の一貫使用、コメントはWHY
+- **Completeness**（5項目）: DI設定、エラーハンドリング、async/await、リソース破棄
+- **Code Length**（1項目）: 例は15行以内（超過はreferences/へ）
 
-**対策**:
-- 具体的な動詞で始まるシナリオを書く
-- 全ての良い例に対応する悪い例を用意
+### 使うとき
 
-### 3. コード品質不合格
+コード検証で保証すること：
+- コピー&ペーストで動く
+- 段階的に学べる
+- 本番向けパターンが示される
 
-**よくある問題**:
-- コンパイルできないコード
-- using文が欠落
+**合格基準**: 13/16 (81%) 以上
 
-**対策**:
-- 実際にプロジェクトでコードをコンパイルして確認
-- 完全なファイル例を提示
+### 設定例
 
-### 4. 言語・表現不合格
+**コード品質チェック**:
 
-**よくある問題**:
-- 長文（1文50単語以上）
-- 受動態の多用
+```python
+# ✅ CORRECT - Validate code markers and comment quality
+import re
 
-**対策**:
-- 各文を20単語以内に分割
-- 能動態に書き換え（例: "is recommended" → "Recommend"）
+# Check 3.3.1: Validate ✅/❌ markers are used consistently
+code_blocks = re.findall(r'```\w+\n(.*?)```', content, re.DOTALL)
+for block in code_blocks:
+    if re.search(r'\bclass\b|\bpublic\b', block):
+        assert re.search(r'//\s*[✅❌]', block), "Missing ✅/❌ marker"
+
+# Check 3.3.3: Comments explain WHY not WHAT
+WHAT_PATTERNS = [r'//\s*Get\s+\w+', r'//\s*Set\s+\w+', r'//\s*Call\s+\w+']
+for block in code_blocks:
+    for pattern in WHAT_PATTERNS:
+        assert not re.search(pattern, block), "Comment explains WHAT, should explain WHY"
+
+# ✅ NEW - Check 3.16: Code example length limit
+for block in code_blocks:
+    lines = [l for l in block.split('\n') if l.strip() and not l.strip().startswith('using')]
+    line_count = len(lines)
+    
+    if line_count <= 15:
+        pass  # ✅ Valid - Inline examples are concise
+    elif line_count <= 20:
+        warnings.append("Code example is 16-20 lines, consider moving to references/")
+    else:
+        # >20 lines should be in references/advanced-examples.md
+        has_advanced_ref = Path('references/advanced-examples.md').exists()
+        assert has_advanced_ref, "Code example >20 lines requires references/advanced-examples.md"
+```
+
+> 📚 **完全な実装**: `references/validation-examples.md` を参照  
+> 📚 **失敗例**: `references/anti-patterns.md` を参照
 
 ---
 
-**このチェックリストの使い方**:
-1. Skill執筆完了後、全項目をチェック
-2. 不合格項目をリストアップ
-3. 優先順位に従って修正
-4. 再度チェックして合格を確認
-5. レビュアーに提出
+## パターン5: 言語・表現検証（11項目）
 
-**目標**: 初回レビューで85%以上、修正後に95%以上を達成
+### 概要
+
+文体、用語の一貫性、可読性、日英対応を検証します。
+
+### 基本例
+
+**主要チェック項目**:
+
+- **Style**（4項目）: 能動態、短文、命令形、曖昧さの排除
+- **Terminology**（3項目）: 用語統一、初出定義、略語展開
+- **Scannability**（3項目）: 見出しと表の明瞭性
+- **Bilingual Support**（1項目）: 英語SKILL.md + 日本語references/SKILL.ja.md（ボーナス）
+- **Scannability**（3項目）: 見出し構造、表の明確さ、重要情報の強調
+
+### 使うとき
+
+言語検証で保証すること：
+- 読みやすさと理解のしやすさ
+- 技術用語の定義
+- ざっと読んでも理解できる構成
+
+**合格基準**: 9/11 (82%) 以上
+
+### 設定例
+
+**言語品質チェック**:
+
+```python
+# ✅ CORRECT - Validate sentence length and active voice
+import re
+
+# Check 5.1.2: Sentences ≤ 20 words
+sentences = re.split(r'[.!?]\s+', text)
+for sentence in sentences:
+    word_count = len(sentence.split())
+    assert word_count <= 20, f"Sentence too long: {word_count} words"
+
+# Check 5.1.1: Detect passive voice
+PASSIVE_INDICATORS = [r'\bis\s+\w+ed\b', r'\bwas\s+\w+ed\b', r'\bcan\s+be\s+\w+ed']
+passive_count = sum(1 for s in sentences for p in PASSIVE_INDICATORS if re.search(p, s))
+passive_ratio = passive_count / len(sentences)
+assert passive_ratio < 0.2, f"Too much passive voice: {passive_ratio:.0%}"
+
+# ✅ NEW - Check 5.11: Bilingual Support
+has_english = Path('SKILL.md').exists()
+has_japanese = Path('references/SKILL.ja.md').exists()
+
+if has_english and has_japanese:
+    bonus_points += 1  # +1 bonus point for bilingual support
+elif not has_english and has_japanese:
+    assert False, "Japanese-only skill - must have English SKILL.md"
+# English-only is acceptable (no penalty)
+```
+
+> 📚 **完全な実装**: `references/validation-examples.md` を参照  
+> 📚 **失敗例**: `references/anti-patterns.md` を参照
+
+---
+
+## パターン6: 品質レポート生成
+
+### 概要
+
+スコアと失敗項目、改善提案を含む詳細レポートを作成します。
+
+### 基本例
+
+**シンプルレポート**:
+
+```markdown
+# Quality Report: skill-name
+
+**Overall**: 52/64 (81%) ✅ PASS
+- Structure: 11/14 (79%) ✅
+- Content: 19/23 (83%) ✅
+- Code Quality: 13/16 (81%) ✅
+- Language: 9/11 (82%) ✅
+- Bonus Points: +1 (Japanese version)
+
+**Critical Issues**:
+- File length: 520 lines (warning: use references/ for >500)
+- Missing Why explanations in Advanced patterns
+```
+
+---
+
+## よくある落とし穴
+
+### 1. 総合80%未満でも通してしまう
+
+**問題**: カテゴリ80%を満たしても全体80%未満で公開される。
+
+**解決策**: 「カテゴリ80%」と「全体80%」の両方を必須にする。
+
+```python
+# ✅ CORRECT - Strict validation
+def is_passing(results: Dict[str, ValidationResult]) -> bool:
+    # Check per-category threshold (80%)
+    if not all(r.score >= 80 for r in results.values()):
+        return False
+    
+    # Check overall threshold (80%, 51/64 points)
+    total_passed = sum(r.passed for r in results.values())
+    total_items = sum(r.total for r in results.values())
+    overall_score = (total_passed / total_items) * 100
+    
+    return overall_score >= 80  # 51/64 = 79.7%, round to 80%
+```
+
+### 2. 文脈を無視したコード品質チェック
+
+**問題**: チュートリアル用途でも本番エラーハンドリング不足として判定する。
+
+**解決策**: スキル種別に応じて検証ルールを調整する。
+
+```yaml
+# In SKILL.md frontmatter
+validation_profile: tutorial  # or: production, reference, quickstart
+
+# Adjust checks based on profile
+if profile == "tutorial":
+    skip_checks = ["3.4.3"]  # Error handling optional for tutorials
+```
+
+### 3. 修正後の再検証をしない
+
+**問題**: 修正で別の問題が発生しても再検証しない。
+
+**解決策**: 変更後は必ずフル検証を再実行。
+
+```bash
+# ❌ WRONG - Fix and assume it's good
+# Edit SKILL.md...
+# Done!
+
+# ✅ CORRECT - Fix and validate
+# Edit SKILL.md...
+python validate_skill.py --skill my-skill --full-check
+```
+
+---
+
+## アンチパターン
+
+### 自動化だけで人間レビューを省略する
+
+**What**: 自動チェックのみでレビューを完結させる。
+
+**Why It's Wrong**:
+- 主観的品質（明確さ、実用性）は検知できない
+- 例が実践的かを判断できない
+- 微妙な不整合を見逃す
+
+**Better Approach**: 自動チェックは基礎、最終は人間レビュー。
+
+---
+
+## クイックリファレンス
+
+### 検証ワークフロー
+
+```
+1. Run structure check (14 items)
+   ├─ PASS: Continue
+   └─ FAIL: Fix structure issues, restart
+
+2. Run content check (23 items)
+   ├─ PASS: Continue
+   └─ FAIL: Improve scenarios, patterns, Values integration
+
+3. Run code quality check (16 items)
+   ├─ PASS: Continue
+   └─ FAIL: Fix code examples, add DI/error handling, shorten long examples
+
+4. Run language check (11 items)
+   ├─ PASS: Calculate overall score
+   └─ FAIL: Rewrite for clarity, active voice, add Japanese version
+
+5. Overall score ≥ 80% AND all categories ≥ 80%?
+   ├─ YES: ✅ PUBLISH
+   └─ NO: Review failures, iterate
+```
+
+---
+
+### 合格基準サマリー
+
+| カテゴリ | 項目数 | 合格基準 | 重み |
+|----------|--------|----------|------|
+| Structure | 14 | ≥ 11 (79%) | Critical |
+| Content | 23 | ≥ 18 (78%) | High |
+| Code Quality | 16 | ≥ 13 (81%) | High |
+| Language | 11 | ≥ 9 (82%) | Medium |
+| **Overall** | **64** | **≥ 51 (80%)** | **Required** |
+| **Bonus** | **+2** | **Japanese + Values** | **Optional** |
+
+---
+
+## ベストプラクティスまとめ
+
+1. **早期・高頻度で実行** - 完成後だけでなく執筆中に検証
+2. **構造を最優先** - 構造エラーは他の検証を阻害
+3. **自動化を活用** - .ps1/.shで繰り返し作業を簡略化
+4. **重大失敗を優先** - 構造/内容 → 言語の順に修正
+5. **90%+を目標** - 初回80%は許容、改訂で90%へ
+6. **例外を記録** - 意図的にスキップする項目を明記
+7. **最終レビューは人間** - 自動チェック + 人間レビュー
+8. **変更後は再検証** - 修正で別の問題が出る前提
+9. **改善を追跡** - スコアの推移を記録
+10. **レポートを学習に活用** - 失敗傾向から改善
+11. **references/を活用** - 500行超は詳細を移動
+12. **Values統合** - Core Principlesに開発哲学を反映
+
+---
+
+## リソース
+
+- **[references/anti-patterns.md](references/anti-patterns.md)** - 詳細な❌例と失敗パターン
+- **[references/validation-examples.md](references/validation-examples.md)** - 検証ロジック実装例
+- **[skill-writing-guide](../skill-writing-guide/SKILL.md)** - Skill執筆ガイド
+- **[skill-revision-guide](../skill-revision-guide/SKILL.md)** - 修正ガイド
+- **[Development Philosophy](../../.github/copilot-instructions.md)** - Valuesと規範
+
+---
+
+## 変更履歴
+
+### Version 3.0.0 (2026-02-12)
+- **チェックリスト拡張**: 56 → 64項目（+8）
+- **行数最適化追加**: 500行推奨、550行許容
+- **references/検証追加**: ディレクトリ構造の検証
+- **日英対応追加**: 日本語版ボーナス
+- **Values統合追加**: 開発哲学整合チェック
+- **コード長制限追加**: 例は15行以内推奨
+- **Progressive Disclosure追加**: >500行はreferences/へ
+- **しきい値更新**: 全体85% → 80%（51/64）
+- **新スクリプト**: PowerShell/Bashラッパー追加
+
+### Version 2.0.0 (2026-02-12)
+- **行数最適化**: 780行 → 335行（57%削減）
+- **アンチパターン移動**: `references/anti-patterns.md`へ
+- **検証ロジック簡略化**: 擬似コード化
+- **56項目維持**: 既存基準を保持
+- **相互参照追加**: anti-patterns/validation-examples
+
+### Version 1.0.0 (2026-02-12)
+- 初版リリース
+- 56項目チェックリスト
+- 4カテゴリスコアリング
+- 自動検証例
+- レポート生成パターン
+
+<!-- 
+Japanese version available at references/SKILL.ja.md
+日本語版は references/SKILL.ja.md を参照してください
+-->

--- a/skills/skill-writing-guide/references/SKILL.ja.md
+++ b/skills/skill-writing-guide/references/SKILL.ja.md
@@ -1,200 +1,195 @@
+---
+name: skill-writing-guide
+description: 高品質なGitHub Copilot agentスキル執筆ガイド。SKILL.md作成時に使用する。
+author: RyoMurakami1983
+tags: [copilot, agent-skills, documentation, writing-guide]
+invocable: false
+---
+
 # Skill執筆ガイド
 
-**作成日**: 2026-02-07  
-**バージョン**: 1.0.0
+公式仕様とベストプラクティスに従って高品質なGitHub Copilot agentスキルを作成するための包括的ガイドです。
 
-このガイドは、高品質なSkillを作成するための実践的な執筆ルールとベストプラクティスを提供します。
+## このスキルを使うとき
 
----
-
-## 📋 目次
-
-1. [基本原則](#基本原則)
-2. [ファイル構造](#ファイル構造)
-3. [YAML Frontmatter](#yaml-frontmatter)
-4. [セクション執筆ルール](#セクション執筆ルール)
-5. [コード例のベストプラクティス](#コード例のベストプラクティス)
-6. [比較表の作成方法](#比較表の作成方法)
-7. [Anti-PatternsとPitfallsの書き分け](#anti-patternsとpitfallsの書き分け)
-8. [言語とトーン](#言語とトーン)
-9. [品質チェックリスト](#品質チェックリスト)
+以下の状況で活用してください：
+- GitHub Copilot agent向けの新しいSKILL.mdをゼロから作成するとき
+- 必須構造やセクションを学びたいとき
+- コード例のベストプラクティスと書式を理解したいとき
+- When to UseやPatternのレイアウトを設計するとき
+- 開発者向けに明確で実行可能なドキュメントを書きたいとき
+- GitHub Copilot/Claude仕様への準拠を確認したいとき
 
 ---
 
-## 基本原則
+## 関連スキル
 
-### 1. 単一ファイル原則
-
-✅ **DO**: SKILL.md のみで完結させる  
-❌ **DON'T**: 追加のサポートファイルを作成しない
-
-**理由**: 
-- 読者が一箇所で全情報を得られる
-- メンテナンス性が高い
-- 検索性が向上
-
-### 2. 読者ファーストの設計
-
-✅ **DO**: 読者が5秒以内に「このSkillは自分に関係あるか」を判断できるようにする  
-❌ **DON'T**: 抽象的な説明から始めない
-
-**実装方法**:
-- "When to Use This Skill" セクションを最優先配置
-- 具体的なユースケースを箇条書き
-- 各項目は50-100文字以内
-
-### 3. 段階的な学習体験
-
-✅ **DO**: Simple → Intermediate → Advanced の順でコード例を提示  
-❌ **DON'T**: いきなり複雑なコードを見せない
-
-**実装方法**:
-- 各パターンで最低3段階の例を用意
-- 各段階で「なぜこの進化が必要か」を説明
-
-### 4. Problem-Solution構造
-
-✅ **DO**: 「なぜこのパターンが必要か」を先に説明  
-❌ **DON'T**: いきなり解決策を提示しない
-
-**実装方法**:
-- 悪い例（❌）→ 良い例（✅）のペアで提示
-- Why を必ず含める
-
-### 5. 実用性の重視
-
-✅ **DO**: コピー&ペーストで動くコードを提供  
-❌ **DON'T**: 抽象的な疑似コードや理論のみ
-
-**実装方法**:
-- 全コード例をコンパイル可能にする
-- 必要なusing文やDI設定を含める
+- **`skill-template-generator`** - SKILL.mdテンプレート生成
+- **`skill-quality-validation`** - Skill品質の検証とスコアリング
+- **`skill-revision-guide`** - 既存Skillの改訂と維持
 
 ---
 
-## ファイル構造
+## コア原則
 
-### ディレクトリ配置
-
-```
-.github/skills/
-└── your-skill-name/
-    └── SKILL.md          # ← 唯一のファイル
-```
-
-### 命名規則
-
-- **フォルダ名**: kebab-case（例: `wpf-mvvm-ddd-enterprise`）
-- **SKILL.md**: 固定（全て大文字）
-- **name** (frontmatter): フォルダ名と一致
+1. **単一ファイル原則** - すべての内容はSKILL.mdに集約し、補助ファイルを増やさない
+2. **読者ファースト** - 5秒で関連性を判断できる構成にする
+3. **段階的学習** - Simple → Intermediate → Advancedの順で例を提示
+4. **問題→解決の順序** - 先に「なぜ」を説明する（成長の複利）
+5. **実用性重視** - コピー&ペーストで動くコードを提供
+6. **価値観の統合** - 開発哲学（基礎と型、継続は力、ニュートラル）と整合
 
 ---
 
-## YAML Frontmatter
+## パターン1: YAML Frontmatter構造
 
-### 必須フィールド
+### 概要
+
+YAML frontmatterはスキルのメタデータを定義し、いつどのようにスキルが起動されるかを決定します。適切な設定は発見性に直結します。
+
+### 基本例
 
 ```yaml
 ---
-name: your-skill-name        # kebab-case, フォルダ名と一致
-description: One-line description of what problem this skill solves
-invocable: false             # 通常は false
----
-```
-
-### オプションフィールド
-
-```yaml
----
-name: skill-name
-description: Description here
+name: your-skill-name
+description: One-line description of what problem this skill solves (100 chars max)
 invocable: false
-tags: [csharp, dotnet, aspire]          # 関連技術タグ
-version: 1.0.0                           # セマンティックバージョニング
-author: GitHub Copilot Team              # 作成者
-last_updated: 2026-02-07                 # 最終更新日
 ---
 ```
 
-### 執筆ルール
+### 使うとき
 
-| フィールド | ルール | 例 |
-|-----------|--------|-----|
-| `name` | kebab-case、フォルダ名と一致 | `wpf-mvvm-patterns` |
-| `description` | 100文字以内、1行、問題解決にフォーカス | `Implement MVVM in WPF with DDD patterns` |
-| `invocable` | 通常は `false` | `false` |
-| `tags` | 3-5個、技術スタック中心 | `[wpf, mvvm, ddd, csharp]` |
+| シナリオ | 設定 | 理由 |
+|----------|------|------|
+| 個人スキル | `invocable: false` | 多くのスキルの標準設定 |
+| 明示的起動が必要 | `invocable: true` | ユーザーが明示的に呼び出せる |
+| 技術特化 | `tags: [tech1, tech2]` | 発見性が向上 |
+
+### 設定例
+
+```yaml
+---
+name: skill-writing-guide
+description: Guide for writing high-quality GitHub Copilot agent skills. Use when creating new SKILL.md files or structuring skill content.
+author: RyoMurakami1983
+tags: [copilot, agent-skills, documentation]
+invocable: false
+---
+```
+
+### 上級パターン（本番向け）
+
+```yaml
+---
+name: wpf-mvvm-patterns
+description: Implement MVVM in WPF with domain-driven design, dependency injection, and testability. Use when building enterprise WPF applications with complex business logic.
+author: RyoMurakami1983
+tags: [wpf, mvvm, ddd, csharp, dotnet]
+invocable: false
+license: MIT
+version: 1.2.0
+---
+```
+
+**フィールド指針**:
+- **name**: kebab-case、フォルダ名と一致、最大64文字
+- **description**: 100文字以内、"Use when..."で起動条件を明示
+- **author**: システム作成スキルは`RyoMurakami1983`
+- **tags**: 3-5個の技術タグ
+- **invocable**: 通常は`false`
 
 ---
 
-## セクション執筆ルール
+## パターン2: "When to Use This Skill" セクション
 
-### 1. "When to Use This Skill" セクション
+### 概要
 
-**目的**: 読者が5秒で関連性を判断できるようにする
+タイトル直後に配置する最初のH2セクションです。読者が「今の課題に関係があるか」を素早く判断できます。
 
-**フォーマット**:
+### 基本例
+
 ```markdown
 ## When to Use This Skill
 
 Use this skill when:
-- Designing public APIs for NuGet packages or libraries
+- Designing public APIs for NuGet packages
 - Making changes to existing public APIs
-- Planning wire format changes for distributed systems
-- Implementing versioning strategies
-- Reviewing pull requests for breaking changes
+- Planning wire format changes
 ```
 
-**ルール**:
-- ✅ 5-8個の具体的なシナリオ
-- ✅ 動詞で始める（Designing, Implementing, Building, etc.）
-- ✅ 各項目は50-100文字
-- ❌ 抽象的な表現（"When you need quality code"）
-- ❌ 10個以上のリスト（冗長）
+### 使うとき
 
-**Good Example**:
+- ✅ **DO**: 5-8個の具体的で行動的なシナリオを書く
+- ✅ **DO**: 各項目を動詞で開始（Designing, Implementing, Building）
+- ✅ **DO**: 各項目は50-100文字以内
+- ❌ **DON'T**: 抽象表現（"When you need quality code"）
+- ❌ **DON'T**: 10個以上並べない
+
+### 設定例
+
 ```markdown
+## When to Use This Skill
+
+Use this skill when:
 - Building enterprise WPF applications with complex business logic
 - Implementing MVVM pattern with domain-driven design
 - Integrating APIs with retry/circuit breaker policies
+- Setting up dependency injection in WPF projects
+- Designing testable ViewModels and Services
+- Managing application state across multiple views
 ```
 
-**Bad Example**:
+### 上級パターン（本番向け）
+
+役割ベースのシナリオを含める：
+
 ```markdown
-- When you want to write good code ← 抽象的すぎ
-- Use WPF ← 技術名だけでシナリオ不明
-- Desktop applications ← 広すぎる
+## When to Use This Skill
+
+Use this skill when:
+- **Architects**: Designing multi-tenant WPF application architecture
+- **Senior Developers**: Implementing advanced MVVM patterns with CQRS
+- **Team Leads**: Reviewing pull requests for MVVM compliance
+- **Junior Developers**: Learning MVVM fundamentals in WPF
+- **DevOps**: Setting up CI/CD pipelines for WPF applications
 ```
 
-### 2. "Core Principles" セクション
+---
 
-**目的**: このSkillの哲学・基盤となる考え方を伝える
+## パターン3: "Core Principles" セクション
 
-**フォーマット**:
+### 概要
+
+スキルの哲学的基盤と指針を定義します。3-5個に絞って簡潔に。
+
+### 基本例
+
 ```markdown
 ## Core Principles
 
-1. **Principle Name** - One-line summary (30-50 chars)
-2. **Another Principle** - One-line summary
-3. **Third Principle** - One-line summary
-```
-
-**ルール**:
-- ✅ 3-5個の原則
-- ✅ 太字で原則名、ハイフン後に説明
-- ✅ 説明は30-50文字
-- ❌ 長文の説明（別セクションで詳述）
-
-**Example**:
-```markdown
 1. **Separation of Concerns** - Views, ViewModels, and Models have distinct responsibilities
 2. **Dependency Inversion** - Depend on abstractions, not concrete implementations
 3. **Testability First** - Design for unit testing from day one
 ```
 
-### 3. パターンセクション（Pattern 1, Pattern 2, ...）
+### 使うとき
 
-**構造**:
+- ✅ **DO**: 3-5個に制限
+- ✅ **DO**: **太字名** - 短い説明（30-50文字）で記述
+- ❌ **DON'T**: 長い説明は後のセクションへ
+
+> 📚 **上級例**: `references/core-principles-examples.md` を参照
+
+---
+
+## パターン4: パターンセクション（7-10必須）
+
+### 概要
+
+各パターンは具体的なアプローチや実装戦略を示します。完成したSkillには7-10個のパターンが必要です。
+
+### 基本例
+
 ```markdown
 ## Pattern 1: [Pattern Name]
 
@@ -210,458 +205,395 @@ Brief explanation (2-3 sentences)
 - Condition A
 - Condition B
 
-### With Configuration
-```csharp
-// ✅ CORRECT - With options
-```
-
 ### Advanced Pattern
 ```csharp
-// ✅ CORRECT - Production-grade
+// ✅ CORRECT - Production-ready
 ```
 ```
 
-**ルール**:
-- ✅ 1つのSkillに7-10個のパターン
-- ✅ 各パターンは独立して理解可能
-- ✅ 進化的な例（Simple → Advanced）
-- ❌ 他のパターンへの強い依存
+### 使うとき
 
-### 4. "Common Pitfalls" セクション
+段階的学習を支える構成：
+1. **Overview**: 何を解決するか
+2. **Basic Example**: 最小の実装
+3. **When to Use**: 判断基準
+4. **Advanced**: 本番向け実装
 
-**目的**: 実装時によくある失敗を予防
-
-**フォーマット**:
-```markdown
-## Common Pitfalls
-
-### 1. Pitfall Name - Brief Description
-
-**Problem**: What users typically do wrong.
-
-```csharp
-// ❌ WRONG
-```
-
-**Solution**: How to fix it.
-
-```csharp
-// ✅ CORRECT
-```
-```
-
-**ルール**:
-- ✅ 3-5個の具体的な失敗例
-- ✅ Problem-Solution構造
-- ✅ 実際のコードで示す
-- ❌ 理論的な説明のみ
-
-### 5. "Anti-Patterns" セクション
-
-**目的**: アーキテクチャレベルの設計ミスを防ぐ
-
-**フォーマット**:
-```markdown
-## Anti-Patterns
-
-### Anti-Pattern Name
-
-**What**: Description of the architectural mistake.
-
-```csharp
-// ❌ WRONG - Architectural flaw
-```
-
-**Why It's Wrong**:
-- Reason 1
-- Reason 2
-
-**Better Approach**:
-
-```csharp
-// ✅ CORRECT - Proper design
-```
-```
-
-**ルール**:
-- ✅ 2-4個のアーキテクチャレベルの問題
-- ✅ Why（なぜダメか）を明確に
-- ✅ Better Approach を必ず提示
-- ❌ Pitfallsと混同しない（後述）
-
-### 6. "Quick Reference" セクション
-
-**目的**: at-a-glance で意思決定できるようにする
-
-**フォーマット**:
-```markdown
-## Quick Reference
-
-| Scenario | Pattern | Code Snippet |
-|----------|---------|--------------|
-| Simple case | Pattern 1 | `new Example()` |
-| With config | Pattern 2 | `services.Configure<T>()` |
-```
-
-**ルール**:
-- ✅ 表形式で簡潔に
-- ✅ 3-5列、5-10行
-- ✅ コードスニペットを含める
-- ❌ 詳細な説明（本文で行う）
+> 📚 **完全な例**: `references/pattern-examples.md` を参照
 
 ---
 
-## コード例のベストプラクティス
+## パターン5: コード例のベストプラクティス
 
-### 1. 段階的な進化
+### 概要
 
-**パターン**: Simple → With Configuration → Advanced
+コード例は実用的かつコンパイル可能で、段階的に複雑化します。✅/❌マーカーを一貫して使用します。
 
-**例**:
+### 基本例
 
-**Level 1: Basic**
-```csharp
-// ✅ CORRECT - Simplest case
-var data = await _client.GetAsync("/api/data");
-```
-
-**Level 2: With Configuration**
-```csharp
-// ✅ CORRECT - With retry policy
-var data = await _retryPolicy.ExecuteAsync(
-    () => _client.GetAsync("/api/data"));
-```
-
-**Level 3: Production-Grade**
-```csharp
-// ✅ CORRECT - With circuit breaker, timeout, and logging
-var data = await _combinedPolicy.ExecuteAsync(
-    async ct =>
-    {
-        _logger.LogInformation("Calling API...");
-        var response = await _client.GetAsync("/api/data", ct);
-        response.EnsureSuccessStatusCode();
-        return await response.Content.ReadFromJsonAsync<Data>(ct);
-    },
-    cancellationToken);
-```
-
-### 2. ✅/❌ マーカーの使用
-
-**ルール**:
-- ✅ `// ✅ CORRECT -` で正しい例を示す
-- ✅ `// ❌ WRONG -` で間違った例を示す
-- ✅ マーカー後に理由を簡潔に追加
-
-**Good Example**:
 ```csharp
 // ✅ CORRECT - Async all the way
-await SomeAsyncMethod();
-
-// ❌ WRONG - Deadlock risk with .Result
-var result = SomeAsyncMethod().Result;
-```
-
-**Bad Example**:
-```csharp
-// Good ← ✅を使うべき
-await SomeAsyncMethod();
-
-// Bad ← ❌を使うべき
-var result = SomeAsyncMethod().Result;
-```
-
-### 3. インラインコメントの書き方
-
-**ルール**:
-- ✅ WHYを説明（HOWはコードで明らか）
-- ✅ 重要な決定ポイントのみ
-- ❌ 冗長なコメント
-
-**Good Example**:
-```csharp
-// ✅ CORRECT - AsNoTracking for read-only queries improves performance
-var orders = await _db.Orders.AsNoTracking().ToListAsync();
-```
-
-**Bad Example**:
-```csharp
-// Get orders from database ← HOWを説明（不要）
-var orders = await _db.Orders.ToListAsync();
-```
-
-### 4. using文とDI設定を含める
-
-**ルール**:
-- ✅ 必要なusing文を明記
-- ✅ DI設定例を含める
-- ❌ "省略" や "..." で済ませない
-
-**Good Example**:
-```csharp
-using Microsoft.Extensions.DependencyInjection;
-using Polly;
-
-// In Program.cs
-builder.Services.AddHttpClient<IApiClient, ApiClient>()
-    .AddTransientHttpErrorPolicy(p => p.WaitAndRetryAsync(3, _ => TimeSpan.FromSeconds(2)));
-```
-
-### 5. 実行可能なコード
-
-**ルール**:
-- ✅ コピー&ペーストでコンパイル可能
-- ✅ 依存関係を明記
-- ❌ 疑似コードや抽象的な例
-
-**Good Example**:
-```csharp
-public class OrderService
+public async Task<Data> GetDataAsync()
 {
-    private readonly IOrderRepository _repository;
-    
-    public OrderService(IOrderRepository repository)
-    {
-        _repository = repository;
-    }
-    
-    public async Task<Order> GetOrderAsync(int id)
-    {
-        return await _repository.GetByIdAsync(id);
-    }
+    return await _client.GetAsync("/api/data");
 }
 
-// In Program.cs
-builder.Services.AddScoped<IOrderRepository, OrderRepository>();
-builder.Services.AddScoped<OrderService>();
+// ❌ WRONG - Blocking async code
+public Data GetData()
+{
+    return _client.GetAsync("/api/data").Result; // Deadlock risk
+}
 ```
+
+### 使うとき
+
+**✅/❌マーカーの使用**:
+- ✅ `// ✅ CORRECT - Reason` で良い例を示す
+- ❌ `// ❌ WRONG - Reason` で悪い例を示す
+- 必ず良い例と悪い例をペアで提示
+
+**コンテキストを含める**:
+- ✅ using文を含める
+- ✅ DI設定を示す
+- ✅ 上級例にはエラーハンドリング
+- ❌ 疑似コードや"..."は使わない
+
+> 📚 **本番向け例**: `references/advanced-examples.md` を参照
 
 ---
 
-## 比較表の作成方法
+## パターン6: 比較表
 
-### 1. 意思決定支援表
+### 概要
 
-**目的**: 読者が「どのパターンを選ぶべきか」を即座に判断できるようにする
+比較表は意思決定を素早く支援します。パターン、ツール、シナリオの比較に使用します。
 
-**フォーマット**:
+### 基本例
+
 ```markdown
 | Scenario | Recommendation | Why |
 |----------|----------------|-----|
 | Read-only data | AsNoTracking() | No change tracking overhead |
 | Update entity | Tracking | Automatic change detection |
-| Bulk operations | ExecuteUpdate() | More efficient than tracking |
 ```
 
-**ルール**:
-- ✅ 3列: Scenario, Recommendation, Why
-- ✅ 5-10行（多すぎない）
-- ✅ 推奨パターンを太字で強調
-- ❌ 詳細な説明（本文で）
+### 使うとき
 
-### 2. 技術比較表
+**意思決定表**:
+- 3列構成（Scenario, Recommendation, Why）
+- 5-10行以内
+- 推奨項目は太字
 
-**目的**: 複数の技術・ツールから選択する際のガイド
+**技術比較表**:
+- Tool, Type, Performance, Use Whenを含める
+- 推奨ツールを太字で強調
 
-**フォーマット**:
+### 設定例
+
 ```markdown
-| Tool | Type | Performance | Use When |
-|------|------|-------------|----------|
-| **Polly** | Resilience | High | HTTP calls, retries |
-| **MediatR** | Messaging | Medium | CQRS, event-driven |
-| Refit | HTTP Client | High | Type-safe REST clients |
-```
-
-**ルール**:
-- ✅ 推奨ツールを太字
-- ✅ 4-6列まで
-- ✅ "Use When" 列を含める
-- ❌ 主観的な評価のみ（定量データも）
-
-### 3. パターン比較表
-
-**フォーマット**:
-```markdown
-| Aspect | Pattern A | Pattern B | Pattern C |
-|--------|-----------|-----------|-----------|
+| Feature | Pattern A | Pattern B | Pattern C |
+|---------|-----------|-----------|-----------|
 | **Complexity** | Low | Medium | High |
-| **Performance** | Fast | Faster | Fastest |
-| **Use Case** | Simple queries | Complex queries | Bulk operations |
+| **Performance** | Good | Better | Best |
+| **Maintainability** | High | Medium | Low |
+| **Use Case** | Simple CRUD | Complex queries | Bulk operations |
+| **Recommendation** | ✅ Start here | Scale to this | **Only if needed** |
 ```
 
 ---
 
-## Anti-PatternsとPitfallsの書き分け
+## パターン7: アンチパターンとよくある落とし穴
 
-### 違いの定義
+### 概要
 
-| 区分 | 対象 | 例 |
-|------|------|-----|
-| **Anti-Patterns** | アーキテクチャ・設計レベルの問題 | God Class, Tight Coupling |
-| **Common Pitfalls** | 実装・使用時のミス | Forgetting await, Null reference |
+設計上の誤り（Anti-Patterns）と実装ミス（Common Pitfalls）を区別します。
 
-### Anti-Patterns の書き方
+### 基本例
 
-**フォーカス**: 設計原則違反、スケーラビリティ問題、保守性の低下
+**Common Pitfall**:
+```csharp
+// ❌ WRONG - Resource not disposed
+var stream = File.OpenRead("file.txt");
 
-**例**:
+// ✅ CORRECT - Automatically disposed
+using var stream = File.OpenRead("file.txt");
+```
+
+### 使うとき
+
+| 種類 | 焦点 | 例 |
+|------|------|----|
+| **Anti-Pattern** | アーキテクチャ、設計原則 | God Class, Tight Coupling |
+| **Common Pitfall** | 実装ミス | Forgetting await, null refs |
+
+> 📚 **詳細**: `references/anti-patterns.md` を参照
+
+---
+
+## パターン8: 500行制限の最適化
+
+### 概要
+
+段階的開示でSKILL.mdを500行以内に保ちつつ品質を維持します。
+
+### コア戦略
+
+**Progressive Disclosure**: 必須内容はSKILL.mdに、詳細はreferences/へ。
+
+```
+┌─────────────────────────────────────┐
+│ SKILL.md (≤500 lines)               │
+│ • ✅ Good patterns (5-15 lines)     │
+│ • Basic examples                    │
+│ • Simple comparisons                │
+└─────────────────────────────────────┘
+           ↓ references
+┌─────────────────────────────────────┐
+│ references/ (loaded when needed)    │
+│ • ❌ Anti-pattern details           │
+│ • 📚 Advanced implementations       │
+│ • ⚙️ Complex configurations         │
+└─────────────────────────────────────┘
+```
+
+### SKILL.mdに残すもの
+
+✅ **残す**（高優先度）:
+1. ✅マーカー付き良い例（5-15行）
+2. 基本的なYAML/markdown例
+3. 簡潔な比較表
+4. コア原則と決定ツリー
+
+### references/へ移すもの
+
+📤 **移動**（低優先度）:
+1. ❌詳細なアンチパターン → `references/anti-patterns.md`
+2. 📚本番向け実装 → `references/advanced-examples.md`
+3. ⚙️複雑な設定 → `references/configuration.md`
+4. 🌏日本語版 → `references/SKILL.ja.md`
+
+### 決定ツリー
+
+| 質問 | 回答 | アクション |
+|------|------|------------|
+| コード例が15行超？ | Yes | references/へ移動を検討 |
+| 基本理解に必須？ | No | references/へ移動 |
+| アンチパターン？ | Yes | references/anti-patterns.mdへ |
+| 上級/本番向け？ | Yes | references/advanced-examples.mdへ |
+| 良い基本例？ | Yes | **SKILL.mdに残す** |
+
+### 基本例
+
+✅ **CORRECT - Concise good pattern**:
+```yaml
+---
+name: wpf-databinding
+description: Guide for WPF data binding patterns. Use when implementing MVVM.
+---
+```
+
+> 📚 **アンチパターンと詳細例**: `references/anti-patterns.md` を参照
+
+### 使うとき
+
+次の条件に該当するとき：
+- SKILL.mdが500行を超えている
+- ✅/❌例が多い
+- 本番向け実装が含まれている
+- 読者の認知負荷を下げたい
+
+---
+
+## よくある落とし穴
+
+### 1. 単一ファイル原則の破り
+
+**問題**: README.mdやexamples.mdなどの補助ファイルで内容が分断される。
+
+```
+❌ WRONG Structure:
+skill-name/
+├── SKILL.md
+├── README.md          # Redundant
+├── examples.md        # Should be in SKILL.md
+└── guidelines.md      # Should be in SKILL.md
+```
+
+**解決策**: すべての内容をSKILL.mdに統合。500行超の場合のみ`references/`で分離。
+
+```
+✅ CORRECT Structure:
+skill-name/
+└── SKILL.md           # Single source of truth
+```
+
+### 2. あいまいな"When to Use"
+
+**問題**: 抽象的なシナリオでは関連性判断ができない。
+
 ```markdown
-### God ViewModel Anti-Pattern
+❌ WRONG:
+- When you want to write good code
+- Use this for WPF applications
+- Helpful for developers
+```
 
-**What**: ViewModelが全ての責務を持つ
+**解決策**: 具体的で行動的なシナリオを書く。
+
+```markdown
+✅ CORRECT:
+- Building enterprise WPF applications with complex business logic
+- Implementing MVVM pattern with dependency injection
+- Designing testable ViewModels with INotifyPropertyChanged
+```
+
+### 3. ✅/❌マーカーの欠落
+
+**問題**: 良い例と悪い例の区別ができない。
 
 ```csharp
-// ❌ WRONG - 1000行のViewModel
-public class MainViewModel
-{
-    // UI logic, business logic, data access, validation...
-}
+// UNCLEAR - Is this good or bad?
+var result = SomeAsyncMethod().Result;
+```
+
+**解決策**: 明示的なマーカーを必ず付ける。
+
+```csharp
+// ❌ WRONG - Deadlock risk with .Result
+var result = SomeAsyncMethod().Result;
+
+// ✅ CORRECT - Async all the way
+var result = await SomeAsyncMethod();
+```
+
+---
+
+## アンチパターン
+
+### 1. 1つのSkillにパターンを詰め込みすぎる
+
+**What**: 20+パターンを含めてスキルが過大化。
+
+**Why It's Wrong**:
+- 推奨される500行制限を超える
+- 内容がスキャンできない
+- 段階的開示に反する
+
+**Better Approach**: スキルを分割する。
+
+```markdown
+❌ WRONG: wpf-everything-guide (30 patterns)
+
+✅ CORRECT:
+- wpf-mvvm-fundamentals (8 patterns)
+- wpf-data-binding-patterns (7 patterns)
+- wpf-performance-optimization (7 patterns)
+```
+
+### 2. 起動条件が不明確なSkill
+
+**What**: 汎用的すぎるdescription。
+
+```yaml
+❌ WRONG:
+description: A helpful guide for WPF development
 ```
 
 **Why It's Wrong**:
-- Violates Single Responsibility Principle
-- Difficult to test
-- Hard to maintain
+- GitHub Copilotが起動条件を判断できない
+- 読者に発見されない
 
-**Better Approach**:
-```csharp
-// ✅ CORRECT - 責務を分離
-public class MainViewModel
-{
-    private readonly IOrderService _orderService;
-    // Only UI logic
-}
-```
-```
+**Better Approach**: descriptionに"Use when..."を含める。
 
-### Common Pitfalls の書き方
-
-**フォーカス**: 実装ミス、よくある間違い、Silent failures
-
-**例**:
-```markdown
-### Forgetting AsNoTracking for Read-Only Queries
-
-**Problem**: Change tracking オーバーヘッドが発生
-
-```csharp
-// ❌ WRONG - Tracking for read-only data
-var orders = await _db.Orders.ToListAsync();
-```
-
-**Solution**:
-
-```csharp
-// ✅ CORRECT - AsNoTracking for reads
-var orders = await _db.Orders.AsNoTracking().ToListAsync();
-```
+```yaml
+✅ CORRECT:
+description: Implement MVVM in WPF with dependency injection and testability. Use when building enterprise WPF applications with complex business logic.
 ```
 
 ---
 
-## 言語とトーン
+## クイックリファレンス
 
-### 1. 明確で簡潔な表現
+### Skill構成チェックリスト
 
-✅ **DO**: 能動態、短文、具体的な用語  
-❌ **DON'T**: 受動態、長文、曖昧な表現
+- [ ] YAML frontmatter（name, description, author, tags）
+- [ ] H1タイトルがSkill名と一致
+- [ ] Related Skillsセクション
+- [ ] "When to Use This Skill" が最初のH2（5-8シナリオ）
+- [ ] Core Principles（3-5原則）
+- [ ] 7-10個のPatternセクション（段階的例付き）
+- [ ] Common Pitfalls（3-5項目）
+- [ ] Anti-Patterns（2-4項目）
+- [ ] Quick Reference または Decision Tree
+- [ ] Best Practices Summary
+- [ ] Resourcesセクション
+- [ ] Changelog（大きい場合はCHANGELOG.mdへリンク）
 
-**Good Example**:
-> "Use `AsNoTracking()` for read-only queries to improve performance."
+### セクション執筆チェックリスト
 
-**Bad Example**:
-> "It is recommended that `AsNoTracking()` should be used in scenarios where data is being read without the intention of modification, as this can potentially lead to performance improvements."
+- [ ] ✅/❌マーカーを一貫して使用
+- [ ] using文とDI設定を含める
+- [ ] WHYを説明し、WHATに留めない
+- [ ] SKILL.mdを500行以内に保つ
+- [ ] 判断支援に表を使う
+- [ ] "When to Use"項目は動詞で開始
+- [ ] Core Principlesは独立して簡潔に
+- [ ] パターン構成: Overview → Basic → Configuration → Advanced
 
-### 2. 一貫した用語
+### コード品質チェックリスト
 
-✅ **DO**: 同じ概念に同じ用語を使う  
-❌ **DON'T**: 類義語を混在させる
-
-**Example**:
-- 一貫して "ViewModel" を使う（"View Model", "VM" を混ぜない）
-- 一貫して "dependency injection" を使う（"DI", "IoC" を混ぜない）
-
-### 3. 技術用語の定義
-
-✅ **DO**: 初出時に簡潔に定義  
-❌ **DON'T**: 読者が知っている前提
-
-**Example**:
-> "MVVM (Model-View-ViewModel) is an architectural pattern that separates UI logic from business logic."
-
-### 4. 命令形の使用
-
-✅ **DO**: "Use", "Implement", "Avoid"  
-❌ **DON'T**: "You should", "It is better to"
-
-**Good Example**:
-> "Implement INotifyPropertyChanged for data binding."
-
-**Bad Example**:
-> "You should implement INotifyPropertyChanged if you want data binding to work."
+- [ ] すべてのコード例がコンパイル可能
+- [ ] 上級例にエラーハンドリングがある
+- [ ] AsyncメソッドにCancellationTokenを含む
+- [ ] リソースが確実に破棄される（using）
+- [ ] 適切なDI設定が示されている
 
 ---
 
-## 品質チェックリスト
+## ベストプラクティスまとめ
 
-執筆完了後、以下をチェック：
-
-### 構造チェック（10項目）
-
-- [ ] ✅ SKILL.md 単一ファイルのみ
-- [ ] ✅ YAML frontmatter が正しい
-- [ ] ✅ "When to Use" が最初のセクション
-- [ ] ✅ Core Principles を含む
-- [ ] ✅ 7-10個のパターンセクション
-- [ ] ✅ Problem-Solution 構造
-- [ ] ✅ 比較表が含まれている
-- [ ] ✅ Anti-Patterns セクションがある
-- [ ] ✅ Common Pitfalls セクションがある
-- [ ] ✅ Quick Reference または Decision Tree がある
-
-### 内容チェック
-
-- [ ] 全コード例がコンパイル可能
-- [ ] ✅/❌ マーカーが一貫している
-- [ ] using文やDI設定が含まれている
-- [ ] 段階的な例（Simple → Advanced）
-- [ ] Why が説明されている
-- [ ] 具体的なシナリオが5個以上
-- [ ] Related Skills のリンクが正しい
-
-### 言語チェック
-
-- [ ] 能動態で書かれている
-- [ ] 一文が50文字以内（英語なら20単語以内）
-- [ ] 専門用語が初出時に定義されている
-- [ ] 一貫した用語使用
-
-### 読みやすさチェック
-
-- [ ] 見出しのみをスキャンして構造が理解できる
-- [ ] コード例にインラインコメントがある
-- [ ] 表が見やすい（3-6列）
-- [ ] セクションの長さが適切（500-1000文字）
+1. **単一ファイル原則** - 内容はSKILL.mdに集約し分割しない
+2. **起動条件を明確化** - descriptionに具体的な"Use when"を書く
+3. **段階的な複雑度** - Basic → Configuration → Advancedで構成
+4. **マーカー統一** - ✅/❌をすべてのコード例で使用
+5. **行動的なシナリオ** - "When to Use"は動詞開始
+6. **WHYを説明** - コードコメントは理由を説明
+7. **7-10パターン** - 過不足なく網羅
+8. **比較表を活用** - 意思決定を支援
+9. **アンチパターンと落とし穴を分離** - 設計と実装を区別
+10. **500行制限** - 追加情報はreferences/へ
 
 ---
 
-## まとめ
+## リソース
 
-高品質なSkillは以下を満たす：
-
-1. **明確な価値提案** - "When to Use" で即座に関連性が分かる
-2. **段階的な学習** - Simple → Advanced の進化
-3. **実用性** - コピペで動くコード
-4. **問題解決フォーカス** - Why を説明
-5. **一貫性** - フォーマット、用語、マーカー
-6. **完全性** - using文、DI、エラーハンドリング
-7. **意思決定支援** - 比較表、Decision Tree
-8. **失敗予防** - Anti-Patterns, Pitfalls
-9. **保守性** - 単一ファイル、明確な構造
-10. **読みやすさ** - スキャン可能、簡潔な文章
-
-このガイドに従えば、`.github/skills/` の既存Skillと同等の品質を達成できます。
+- [GitHub Copilot Agent Skills Documentation](https://docs.github.com/en/copilot/concepts/agents/about-agent-skills)
+- [Claude Skills Documentation](https://claude.com/docs/skills/overview)
+- [Agent Skills Specification](https://agentskills.io/specification)
+- [SKILL_TEMPLATE.md](../../.copilot/docs/SKILL_TEMPLATE.md) - English template
+- [SKILL_TEMPLATE.ja.md](../../.copilot/docs/SKILL_TEMPLATE.ja.md) - Japanese template
 
 ---
 
-**次のステップ**: [SKILL_QUALITY_CHECKLIST.md](./SKILL_QUALITY_CHECKLIST.md) で品質を検証
+## 変更履歴
+
+CHANGELOG.mdに詳細を記載。直近の変更：
+
+### Version 2.0.0 (2026-02-12)
+- **Core Principles拡張**: Values統合（基礎と型、成長の複利、温故知新、継続は力、ニュートラル）
+- **Pattern 8更新**: 500行推奨 + 550行許容（+10%）
+- **開発哲学の統合**: Valuesとパターンを整合
+- **WHY説明の強調**: 成長の複利に沿った説明追加
+- **品質検証同期**: skill-quality-validation 64項目と整合
+
+### Version 1.0.0 (2026-02-12)
+- 初版リリース
+- 8パターンを収録
+- コード例ベストプラクティス定義
+- アンチパターンと落とし穴の区別
+- 段階的開示戦略を導入
+
+<!-- 
+Japanese version available at references/SKILL.ja.md
+日本語版は references/SKILL.ja.md を参照してください
+-->


### PR DESCRIPTION
## 概要
- git init/clone時のmain保護をデフォルト化するskillを追加
- pre-commit/pre-pushフックとセットアップを追加
- 参照・READMEを更新し、日英を整合

## テスト
- uv run python C:\Users\murak\dev\skills_repository\skills\skill-quality-validation\scripts\validate_skill.py C:\Users\murak\dev\skills_repository\skills\skill-git-initial-setup\SKILL.md

## 関連
Closes #4
Closes #6