### PR TITLE
feat: production向けTDDスキル追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 | カテゴリ | 説明 | 配置先 | Skills数 | 詳細 |
 |---------|------|--------|---------|------|
 | `skills/` | Skill作成支援（Meta-Skills） | グローバル（~/.copilot/skills/） | 10 | [SKILLS_README.md](skills/SKILLS_README.md) |
+| `production/` | MVP/本番向け開発プラクティス | プロジェクト（.github/skills/） | 1 | [PRODUCTION_SKILLS_README.md](production/PRODUCTION_SKILLS_README.md) |
 
 ### 📌 今後追加予定のカテゴリ
 
@@ -74,9 +75,15 @@ Copy-Item -Recurse C:\temp\skills-repository\skills\* $env:USERPROFILE\.copilot\
 Get-ChildItem $env:USERPROFILE\.copilot\skills\
 ```
 
-### プロジェクトインストール（プロジェクト固有） - 今後対応予定
+### プロジェクトインストール（プロジェクト固有）
 
-今後追加される言語別Skillsは、プロジェクトの`.github/skills/`にコピーして使用します。
+production/ や言語別Skillsは、プロジェクトの`.github/skills/`にコピーして使用します。
+
+**例: Production Skillsをプロジェクトに追加**:
+```bash
+mkdir -p .github/skills
+cp -r /tmp/skills-repository/production/* .github/skills/
+```
 
 **例: Python Skillsをプロジェクトに追加**（今後実装予定）:
 ```bash
@@ -121,6 +128,7 @@ GitHub Copilot Chat内で直接Meta-Skillsを呼び出すことができます�
 
 - **[repository-structure-plan.md](repository-structure-plan.md)** - リポジトリ構造の詳細設計
 - **[skills/SKILLS_README.md](skills/SKILLS_README.md)** - Meta-Skills詳細情報
+- **[production/PRODUCTION_SKILLS_README.md](production/PRODUCTION_SKILLS_README.md)** - Production Skills詳細情報
 - **[skill-quality-gaps-analysis.md](skill-quality-gaps-analysis.md)** - 品質分析レポート
 
 ## 🤝 貢献
@@ -129,7 +137,7 @@ GitHub Copilot Chat内で直接Meta-Skillsを呼び出すことができます�
 
 ### 新しいSkillを追加する
 
-1. **適切なカテゴリを選択** - 現在は`skills/`のみ、今後他カテゴリも追加予定
+1. **適切なカテゴリを選択** - 現在は`skills/`と`production/`、今後他カテゴリも追加予定
 2. **テンプレート生成** - `skill-template-generator`を使用
 3. **内容を作成** - `skill-writing-guide`を参考に記述
 4. **品質検証** - `skill-quality-validation`で64項目チェック
@@ -163,6 +171,10 @@ GitHub Copilot Chat内で直接Meta-Skillsを呼び出すことができます�
 - **Discussions**: 質問や議論は[GitHub Discussions](https://github.com/your-org/skills-repository/discussions)へ
 
 ## 🔄 バージョン履歴
+
+### v1.1.0 (2026-02-13)
+- Productionカテゴリを追加
+- tdd-standard-practice を追加
 
 ### v1.0.0 (2026-02-12)
 - 初回リリース

--- a/production/PRODUCTION_SKILLS_README.md
+++ b/production/PRODUCTION_SKILLS_README.md
@@ -1,0 +1,38 @@
+# Production Skills: MVP/本番向け開発プラクティス
+
+MVPと本番環境で品質と速度のバランスを保つためのSkillsをまとめたカテゴリです。
+
+## 📋 概要
+
+このカテゴリには、プロトタイプではなくMVP/本番フェーズで使う開発プラクティスを収録します。
+
+## 🎯 用途
+
+**プロジェクト固有のSkills**として、必要なものだけを`.github/skills/`にコピーして使用します。
+
+## 📦 収録Skills
+
+| Skill名 | 説明 | バージョン | 主な機能 |
+|---------|------|------------|----------|
+| [tdd-standard-practice](tdd-standard-practice/) | TDD標準プラクティス | 1.0.0 | テストリスト、Red-Green-Refactor、モック/スタブ、CI |
+
+## 🔧 依存関係
+
+- テストフレームワーク（pytest, NUnit, Jest等）
+- CIでテストを実行できる環境
+
+## 📖 各Skillの詳細
+
+### 1. tdd-standard-practice
+
+**MVP/本番でのTDDワークフロー標準化**
+
+- テストリストの作成方法
+- Red-Green-Refactorの基本サイクル
+- モック/スタブの境界設計
+- CI/CDでのガードレール設計
+
+**使い方**:
+```
+@workspace /tdd-standard-practice MVP/本番のTDDを標準化したい
+```

--- a/production/tdd-standard-practice/SKILL.md
+++ b/production/tdd-standard-practice/SKILL.md
@@ -1,0 +1,457 @@
+---
+name: tdd-standard-practice
+description: Standardize a production TDD workflow with test lists and Red-Green-Refactor.
+author: RyoMurakami1983
+tags: [tdd, testing, workflow, ci, quality]
+invocable: false
+version: 1.0.0
+---
+
+# TDD Standard Practice (Production)
+
+Standardize a Test-Driven Development (TDD) workflow that balances delivery speed and production safety for Minimum Viable Product (MVP) and production systems.
+
+**Test List**: A short backlog of behaviors to implement one at a time.  
+**Red-Green-Refactor**: Write a failing test, make it pass, then clean up.  
+**Developer Testing**: Developers verify their own code with automated tests.
+
+Progression: Simple -> Intermediate -> Advanced examples improve reliability because each stage tightens feedback loops.  
+Reason: Tight loops prevent uncertainty and keep changes safe.
+
+## When to Use This Skill
+
+Use this skill when:
+- Building MVP or production features that must keep behavior stable under change.
+- Changing core logic where customer-visible outcomes must stay consistent.
+- Refactoring large modules while keeping a fast safety net of tests.
+- Integrating AI-generated code and proving it with executable tests.
+- Establishing a team-wide TDD workflow with shared red-green rules.
+- Reducing defect leakage into staging or production releases.
+
+## Related Skills
+
+- **`skill-git-commit-practices`** - Commit hygiene for small safe steps
+- **`skill-git-review-standards`** - Review quality and evidence checks
+- **`skill-issue-intake`** - Capture deferred test debt as issues
+
+---
+
+## Dependencies
+
+- Unit test framework (pytest, NUnit, Jest, etc.)
+- Local test runner and fast feedback loop
+- Continuous Integration (CI) pipeline to run tests on every change
+
+---
+
+## Core Principles
+
+1. **Test List First** - Capture behavior before coding (基礎と型)
+2. **One Step at a Time** - Red then green before refactor (継続は力)
+3. **Behavior over Implementation** - Test public behavior (ニュートラル)
+4. **Developer Testing** - Close the feedback loop (成長の複利)
+5. **Learn and Improve** - Refactor based on test feedback (温故知新)
+
+---
+
+## Pattern 1: Build a Test List
+
+### Overview
+
+Create a small, explicit list of behaviors and pick one item at a time.
+
+### Basic Example
+
+```text
+# ✅ CORRECT - pick one item
+Test list:
+- Reject empty email
+- Accept valid email
+Pick one: Reject empty email
+
+# ❌ WRONG - multiple targets at once
+Test list:
+- Reject empty email
+- Accept valid email
+- Normalize case
+Pick one: All three
+```
+
+### Intermediate Example
+
+- Order the list by risk and user impact
+- Add a "done" checkmark for completed items
+
+### Advanced Example
+
+```markdown
+## Test list (PR description)
+- [x] Reject empty email
+- [ ] Accept valid email
+- [ ] Normalize case
+```
+
+### When to Use
+
+- At the start of a feature or bug fix
+- When requirements are still fuzzy
+
+**Why**: The list prevents skipping steps and keeps focus on one behavior.  
+**Values**: 基礎と型 / 成長の複利
+
+---
+
+## Pattern 2: Red-Green-Refactor Loop
+
+### Overview
+
+Run the shortest cycle: failing test, passing code, then cleanup.
+
+### Basic Example
+
+```python
+from decimal import Decimal
+
+# Red
+def test_price_with_tax():
+    assert price_with_tax(Decimal("100.00")) == Decimal("110.00")
+```
+
+```python
+from decimal import Decimal
+
+# Green
+def price_with_tax(amount: Decimal) -> Decimal:
+    return (amount * Decimal("1.1")).quantize(Decimal("1.00"))
+```
+
+### Intermediate Example
+
+- Refactor duplicate setup after the test passes
+- Keep the red-green cycle under 10 minutes
+
+### Advanced Example
+
+- Commit after each green step
+- Use a refactor checklist before merging
+
+### When to Use
+
+- For every behavior on the test list
+
+**Why**: Small cycles reduce uncertainty and simplify debugging.  
+**Values**: 継続は力 / 成長の複利
+
+---
+
+## Pattern 3: Test First in Small Steps
+
+### Overview
+
+Write one failing assertion that defines the next behavior.
+
+### Basic Example
+
+```python
+def test_empty_email_is_invalid():
+    assert is_valid_email("") is False
+```
+
+### Intermediate Example
+
+- One assertion per test case
+- Avoid multiple failures in a single test
+
+### Advanced Example
+
+- Use parameterized tests only after basic cases are green
+
+### When to Use
+
+- When behavior is simple and deterministic
+
+**Why**: One failing test keeps the next action obvious.  
+**Values**: 基礎と型 / 継続は力
+
+---
+
+## Pattern 4: Test Public Behavior First
+
+### Overview
+
+Focus tests on public interfaces and user-visible outcomes.
+
+### Basic Example
+
+```python
+result = invoice.total_with_tax()
+assert result == 110
+```
+
+### Intermediate Example
+
+- Prefer API-level tests over internal helpers
+- Name tests in terms of user intent
+
+### Advanced Example
+
+- Add contract tests for service boundaries
+
+### When to Use
+
+- When refactoring internal structure
+- When exposing APIs to other teams
+
+**Why**: Behavior-focused tests survive refactors.  
+**Values**: ニュートラル / 成長の複利
+
+---
+
+## Pattern 5: Mock or Stub at the Boundary
+
+### Overview
+
+Isolate external systems, but keep core logic real.
+
+### Basic Example
+
+```python
+# ✅ CORRECT - mock at boundary
+gateway = FakePaymentGateway()
+service = BillingService(gateway)
+
+# ❌ WRONG - mock inside domain
+pricing = MockPriceCalculator()
+service = BillingServiceWithMock(pricing)
+```
+
+### Intermediate Example
+
+- Use in-memory fakes for databases or queues
+- Mock only network or time dependencies
+
+### Advanced Example
+
+```csharp
+// ✅ CORRECT - DI for test doubles
+using Microsoft.Extensions.DependencyInjection;
+
+var services = new ServiceCollection();
+services.AddSingleton<IPaymentGateway, FakePaymentGateway>();
+services.AddSingleton<BillingService>();
+```
+
+```csharp
+// ❌ WRONG - hard-coded dependency in tests
+var service = new BillingService(new PaymentGateway());
+```
+
+- Enforce a "no mocks inside domain" rule
+
+### When to Use
+
+- When tests become slow or flaky
+
+**Why**: Boundary-only mocks keep tests trustworthy.  
+**Values**: 基礎と型 / ニュートラル
+
+---
+
+## Pattern 6: Refactor After Green
+
+### Overview
+
+Only refactor after tests pass, then re-run tests.
+
+### Basic Example
+
+- Run all tests before refactor
+- Clean duplication after green
+
+### Intermediate Example
+
+- Extract helper methods with no behavior change
+- Keep refactors under 30 minutes
+
+### Advanced Example
+
+- Use automated refactoring tools and re-run tests after each step
+
+### When to Use
+
+- After every green step
+
+**Why**: Refactoring with green tests keeps safety and speed.  
+**Values**: 温故知新 / 継続は力
+
+---
+
+## Pattern 7: CI as a Guardrail
+
+### Overview
+
+Make red builds visible and block merges.
+
+### Basic Example
+
+```yaml
+# .github/workflows/tests.yml
+name: tests
+on: [push, pull_request]
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: pytest
+```
+
+### Intermediate Example
+
+- Require test checks for merge
+- Fail fast on red builds
+
+### Advanced Example
+
+```toml
+# pyproject.toml
+[tool.pytest.ini_options]
+addopts = "-q"
+```
+
+File: appsettings.json
+
+```json
+{
+  "Testing": {
+    "FastFail": true
+  }
+}
+```
+
+- Separate unit and integration stages
+- Enforce coverage thresholds on main
+
+### When to Use
+
+- On every repository that ships to production
+
+**Why**: CI turns local discipline into team-wide safety.  
+**Values**: 成長の複利 / 継続は力
+
+---
+
+## Pattern 8: Add Regression Tests for Bugs
+
+### Overview
+
+Reproduce a bug with a failing test before fixing it.
+
+### Basic Example
+
+```python
+def test_discount_rounding_bug():
+    assert apply_discount(100, 0.1) == 90
+```
+
+### Intermediate Example
+
+- Add the test to the test list before coding
+- Reference the issue ID in the test name
+
+### Advanced Example
+
+```python
+from pathlib import Path
+
+def load_fixture(path: str) -> str:
+    try:
+        return Path(path).read_text(encoding="utf-8")
+    except OSError as exc:
+        raise RuntimeError(f"Fixture missing: {path}") from exc
+```
+
+- Keep a "bug diary" section in release notes
+
+### When to Use
+
+- When fixing production defects
+
+**Why**: Regression tests prevent repeat failures.  
+**Values**: 温故知新 / 成長の複利
+
+---
+
+## Best Practices
+
+- Keep tests fast; move slow checks to integration suites
+- Keep one failing test at a time
+- Use descriptive test names that explain behavior
+- Run the full suite before refactor
+- Commit only after green
+- Review test list items during planning
+
+---
+
+## Common Pitfalls
+
+- Writing multiple failing tests at once  
+  Fix: Keep one failing test and finish it before the next.
+- Refactoring before green  
+  Fix: Only refactor after tests pass.
+- Overusing mocks  
+  Fix: Mock only at system boundaries.
+
+---
+
+## Anti-Patterns
+
+- Writing tests after the implementation is done
+- Excessive mocking of internal logic
+- Skipping the test list and jumping to coding
+- Combining multiple behaviors in one test
+
+---
+
+## FAQ
+
+**Q: Is TDD required for prototypes?**  
+A: Use a lighter approach for prototypes; this skill is optimized for MVP and production.
+
+**Q: How big should a test list be?**  
+A: Keep it short and reorder often; the next action should be obvious.
+
+**Q: Can TDD work with legacy code?**  
+A: Yes. Start with characterization tests around the current behavior.
+
+---
+
+## Quick Reference
+
+| Step | Action | Output |
+|------|--------|--------|
+| 1 | Write test list | Next behavior chosen |
+| 2 | Write failing test | Red |
+| 3 | Implement minimal code | Green |
+| 4 | Refactor | Clean code |
+| 5 | Commit + push | CI validates |
+
+```text
+Test list -> Red -> Green -> Refactor -> Commit
+```
+
+---
+
+## Resources
+
+- Kent Beck, "Test-Driven Development by Example"
+- T-Wada: Test list and Red-Green-Refactor workflow
+
+---
+
+## Changelog
+
+### Version 1.0.0 (2026-02-13)
+
+- Initial release
+- Test list, Red-Green-Refactor, CI, and mock discipline patterns

--- a/production/tdd-standard-practice/references/SKILL.ja.md
+++ b/production/tdd-standard-practice/references/SKILL.ja.md
@@ -1,0 +1,457 @@
+---
+name: tdd-standard-practice
+description: MVP/本番向けにTDDを標準化する。テストリストとRed-Green-Refactorで安全に進める。
+author: RyoMurakami1983
+tags: [tdd, testing, workflow, ci, quality]
+invocable: false
+version: 1.0.0
+---
+
+# TDD標準プラクティス（MVP/本番）
+
+Minimum Viable Product (MVP) と本番環境で、速度と品質のバランスを保つためのTest-Driven Development (TDD)ワークフローを標準化します。
+
+**テストリスト**: これから実装する振る舞いを1件ずつ列挙した短いリスト。  
+**Red-Green-Refactor**: 失敗テスト -> 最小実装 -> 整理を繰り返す基本サイクル。  
+**開発者テスト**: 実装者自身が自動テストで振る舞いを検証する考え方。
+
+Progression: Simple -> Intermediate -> Advanced は段階的にフィードバックの精度を高めます。  
+Reason: フィードバックが短いほど不安が減り、変更の安全性が上がります。
+
+## このスキルを使うとき
+
+以下の状況で活用してください：
+- MVP/本番で回帰を避けたい機能を安全に実装したいとき
+- コアロジック変更でユーザー影響を守りたいとき
+- 大規模リファクタの安全性を短いテストで確保したいとき
+- 生成AIコードを手元の自動テストで検証したいとき
+- チームでTDDの手順とRed-Greenルールを揃えたいとき
+- 不具合の流出を減らし、リリースを安定させたいとき
+
+## 関連スキル
+
+- **`skill-git-commit-practices`** - 小さな変更を安全にコミット
+- **`skill-git-review-standards`** - レビューでテスト証跡を確認
+- **`skill-issue-intake`** - テスト負債をIssue化
+
+---
+
+## 依存関係
+
+- 単体テストフレームワーク（pytest, NUnit, Jest等）
+- ローカルで素早く回るテスト実行環境
+- Continuous Integration (CI)でテストを回すパイプライン
+
+---
+
+## コア原則
+
+1. **テストリスト優先** - 実装前に振る舞いを明確化（基礎と型）
+2. **一歩ずつ進む** - Red -> Green -> Refactorの順序厳守（継続は力）
+3. **振る舞い中心** - 公開APIやユーザー視点を基準にする（ニュートラル）
+4. **開発者テスト** - フィードバックを最短化（成長の複利）
+5. **学びと整理** - テスト結果から設計を磨く（温故知新）
+
+---
+
+## パターン1: テストリストを作る
+
+### 概要
+
+振る舞いを短いリストにして、1件ずつ確実に進めます。
+
+### 基本例
+
+```text
+# ✅ CORRECT - 1件ずつ選ぶ
+テストリスト:
+- 空メールは拒否
+- 正しいメールは通す
+次の1件: 空メールは拒否
+
+# ❌ WRONG - 一度に複数を狙う
+テストリスト:
+- 空メールは拒否
+- 正しいメールは通す
+- 大文字小文字を正規化
+次の1件: 全部まとめて
+```
+
+### 中級例
+
+- リスクと影響度で優先度を付ける
+- 完了にチェックを付ける
+
+### 上級例
+
+```markdown
+## テストリスト（PR説明）
+- [x] 空メールは拒否
+- [ ] 正しいメールは通す
+- [ ] 大文字小文字を正規化
+```
+
+### 使うとき
+
+- 機能開発やバグ修正の開始時
+- 要件がまだ曖昧なとき
+
+**Why**: 先にリスト化すると、抜け漏れを防ぎ「次の1手」を迷わず決められます。  
+**Values**: 基礎と型 / 成長の複利
+
+---
+
+## パターン2: Red-Green-Refactorの徹底
+
+### 概要
+
+最短サイクルで失敗 -> 成功 -> 整理を繰り返します。
+
+### 基本例
+
+```python
+from decimal import Decimal
+
+# Red
+def test_price_with_tax():
+    assert price_with_tax(Decimal("100.00")) == Decimal("110.00")
+```
+
+```python
+from decimal import Decimal
+
+# Green
+def price_with_tax(amount: Decimal) -> Decimal:
+    return (amount * Decimal("1.1")).quantize(Decimal("1.00"))
+```
+
+### 中級例
+
+- テストが通ったら重複を削除
+- 10分以内の短いサイクルを維持
+
+### 上級例
+
+- Greenごとにコミット
+- リファクタ用のチェックリストを持つ
+
+### 使うとき
+
+- テストリストの各項目すべて
+
+**Why**: 小さなサイクルは不安とバグの発生源を最小化します。  
+**Values**: 継続は力 / 成長の複利
+
+---
+
+## パターン3: テストファーストは小さく
+
+### 概要
+
+1つの失敗テストで次の振る舞いを定義します。
+
+### 基本例
+
+```python
+def test_empty_email_is_invalid():
+    assert is_valid_email("") is False
+```
+
+### 中級例
+
+- 1テスト1アサーションで意図を明確化
+- 1テストで複数失敗を出さない
+
+### 上級例
+
+- 基本ケースが通ってからパラメータ化
+
+### 使うとき
+
+- 振る舞いがシンプルで明確なとき
+
+**Why**: 1件だけ失敗させると、次に書くコードが自明になります。  
+**Values**: 基礎と型 / 継続は力
+
+---
+
+## パターン4: 公開振る舞いを先にテスト
+
+### 概要
+
+内部実装ではなく、外から見える結果をテストします。
+
+### 基本例
+
+```python
+result = invoice.total_with_tax()
+assert result == 110
+```
+
+### 中級例
+
+- 内部ヘルパーではなく公開APIをテスト
+- テスト名にユーザー意図を書く
+
+### 上級例
+
+- サービス境界の契約テストを追加
+
+### 使うとき
+
+- 内部構造を整理するとき
+- 他チームに公開するAPIを作るとき
+
+**Why**: 振る舞いテストはリファクタに強く、長期的な資産になります。  
+**Values**: ニュートラル / 成長の複利
+
+---
+
+## パターン5: 境界だけモック/スタブ
+
+### 概要
+
+外部依存を隔離し、ドメイン内部は実物で検証します。
+
+### 基本例
+
+```python
+# ✅ CORRECT - 境界だけモック
+gateway = FakePaymentGateway()
+service = BillingService(gateway)
+
+# ❌ WRONG - ドメイン内部をモック
+pricing = MockPriceCalculator()
+service = BillingServiceWithMock(pricing)
+```
+
+### 中級例
+
+- DBやキューはインメモリのFakeを使う
+- モック対象はネットワークや時間に限定
+
+### 上級例
+
+```csharp
+// ✅ CORRECT - DIでテスト用差し替え
+using Microsoft.Extensions.DependencyInjection;
+
+var services = new ServiceCollection();
+services.AddSingleton<IPaymentGateway, FakePaymentGateway>();
+services.AddSingleton<BillingService>();
+```
+
+```csharp
+// ❌ WRONG - テストで依存を直書き
+var service = new BillingService(new PaymentGateway());
+```
+
+- ドメイン内部はモック禁止ルールを定める
+
+### 使うとき
+
+- テストが遅い、または不安定なとき
+
+**Why**: 境界だけモックにすると、テストの信頼性と速度を両立できます。  
+**Values**: 基礎と型 / ニュートラル
+
+---
+
+## パターン6: Greenのあとにリファクタ
+
+### 概要
+
+テストが通ってから整理し、必ず再実行します。
+
+### 基本例
+
+- 先に全テストを通す
+- Green後に重複を削除
+
+### 中級例
+
+- 振る舞い変更を伴わない抽出に限定
+- 30分以内の整理で止める
+
+### 上級例
+
+- 自動リファクタを活用し、各ステップで再実行
+
+### 使うとき
+
+- Greenが確認できた直後
+
+**Why**: Green後の整理は安全に設計を改善できます。  
+**Values**: 温故知新 / 継続は力
+
+---
+
+## パターン7: CIをガードレールにする
+
+### 概要
+
+赤いビルドを見える化し、マージを止めます。
+
+### 基本例
+
+```yaml
+# .github/workflows/tests.yml
+name: tests
+on: [push, pull_request]
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: pytest
+```
+
+### 中級例
+
+- テスト成功をマージ条件にする
+- Redのままでは次へ進めない
+
+### 上級例
+
+```toml
+# pyproject.toml
+[tool.pytest.ini_options]
+addopts = "-q"
+```
+
+ファイル: appsettings.json
+
+```json
+{
+  "Testing": {
+    "FastFail": true
+  }
+}
+```
+
+- ユニットと統合を分離して段階実行
+- mainのカバレッジ閾値を固定
+
+### 使うとき
+
+- 本番に出るリポジトリすべて
+
+**Why**: CIは個人の良い習慣をチームの安全装置に変えます。  
+**Values**: 成長の複利 / 継続は力
+
+---
+
+## パターン8: バグは回帰テストにする
+
+### 概要
+
+不具合を再現するテストを書いてから修正します。
+
+### 基本例
+
+```python
+def test_discount_rounding_bug():
+    assert apply_discount(100, 0.1) == 90
+```
+
+### 中級例
+
+- 修正前にテストリストへ追加
+- テスト名にIssue IDを入れる
+
+### 上級例
+
+```python
+from pathlib import Path
+
+def load_fixture(path: str) -> str:
+    try:
+        return Path(path).read_text(encoding="utf-8")
+    except OSError as exc:
+        raise RuntimeError(f"Fixture missing: {path}") from exc
+```
+
+- リリースノートに「バグ学習メモ」を残す
+
+### 使うとき
+
+- 本番不具合の修正時
+
+**Why**: 回帰テストが再発防止の最短ルートになります。  
+**Values**: 温故知新 / 成長の複利
+
+---
+
+## ベストプラクティス
+
+- テストは高速に保ち、遅い検証は統合側へ移す
+- 失敗テストは常に1件だけ
+- テスト名に振る舞いを明記
+- リファクタ前に必ず全体を通す
+- Greenのあとにコミット
+- テストリストを計画時に見直す
+
+---
+
+## よくある落とし穴
+
+- 失敗テストを複数書いてしまう  
+  Fix: 1件ずつ終わらせる。
+- Green前に整理してしまう  
+  Fix: 必ずGreenのあとに整理する。
+- モックが多すぎて意味が薄い  
+  Fix: 境界だけモックに限定する。
+
+---
+
+## アンチパターン
+
+- 実装後にテストを書く
+- 内部ロジックまで過剰にモックする
+- テストリストを省略して実装に入る
+- 1テストで複数の振る舞いを混ぜる
+
+---
+
+## FAQ
+
+**Q: プロトタイプにもTDDを使うべき？**  
+A: プロトタイプは軽量で十分です。本スキルはMVP/本番向けの標準化を想定しています。
+
+**Q: テストリストはどれくらい書く？**  
+A: 短く保ち、順番を頻繁に入れ替えます。次の1手が明確なら十分です。
+
+**Q: レガシーコードでもTDDできる？**  
+A: 可能です。まずは現状を固定する特性テストから始めます。
+
+---
+
+## クイックリファレンス
+
+| 手順 | アクション | 出力 |
+|------|------------|------|
+| 1 | テストリスト作成 | 次の1件が決まる |
+| 2 | 失敗テストを書く | Red |
+| 3 | 最小実装 | Green |
+| 4 | リファクタ | 整理されたコード |
+| 5 | コミットとプッシュ | CIが検証 |
+
+```text
+テストリスト -> Red -> Green -> Refactor -> Commit
+```
+
+---
+
+## Resources
+
+- Kent Beck, "Test-Driven Development by Example"
+- T-Wada: テストリストとRed-Green-Refactorのワークフロー
+
+---
+
+## Changelog
+
+### Version 1.0.0 (2026-02-13)
+
+- 初版リリース
+- テストリスト、Red-Green-Refactor、CI、モック運用を整理


### PR DESCRIPTION
## 概要

- productionカテゴリREADMEを追加

- TDD標準プラクティススキル（英日）を追加

- ルートREADMEを更新



## テスト

- uv run python skills\\skill-quality-validation\\scripts\\validate_skill.py production\\tdd-standard-practice\\SKILL.md