### PR TITLE
docs: READMEの.copilot/skills同期手順を安全化

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ git clone https://github.com/RyoMurakami1983/skills_repository.git C:\tools\skil
 # 2) 同期先フォルダを作成（初回のみ）
 New-Item -ItemType Directory -Force -Path $env:USERPROFILE\.copilot\skills | Out-Null
 
-# 3) 初回同期（不要ファイルも含めて完全同期）
+# 3) 初回同期（不要ファイル削除も含めて完全同期）
 robocopy C:\tools\skills_repository\skills $env:USERPROFILE\.copilot\skills /MIR
 ```
 
@@ -61,6 +61,16 @@ git clone https://github.com/RyoMurakami1983/skills_repository.git /tmp/skills-r
 mkdir -p ~/.copilot/skills
 cp -r /tmp/skills-repository/skills/* ~/.copilot/skills/
 ```
+
+**Linux/macOS（更新時）**:
+
+```bash
+cd /tmp/skills-repository
+git pull --ff-only
+rsync -a --delete /tmp/skills-repository/skills/ ~/.copilot/skills/
+```
+
+> 注意: `cp -r` の再実行だけでは削除済みSkillが同期先に残る場合があります。更新時は `rsync --delete` を使用してください。
 
 ### プロジェクトインストール（プロジェクト固有）
 


### PR DESCRIPTION
## 概要
README のグローバルインストール手順を更新し、`.copilot\skills` を安全に最新化できる同期フローへ変更しました。

## 変更点
- Windows手順を「専用clone + `git pull --ff-only` + `robocopy /MIR`」に変更
- 初回導入と更新導入を分離
- `/MIR` の注意点（同期先の不要ファイル削除）を明記
- Linux/macOS手順は初回導入として維持

## 目的
単純上書きコピーで古いSkillが残るリスクを減らし、常に最新状態へ安全に同期できるようにするため。

## 関連
- Python開発環境Skillの起票: #29