### PR TITLE
test: PR #28レビュー指摘の追補（カテゴリ数固定assertを廃止）

### DIFF
--- a/skills/skill-quality-validation/scripts/tests/test_validate_skill.py
+++ b/skills/skill-quality-validation/scripts/tests/test_validate_skill.py
@@ -185,6 +185,7 @@ Route to the best matching skill.
     assert check.passed is True
     assert "N/A" in (check.details or "")
 
-    assert len(report.categories) == 4
+    category_names = {c.name for c in report.categories}
+    assert {"Structure", "Content", "Code Quality", "Language"}.issubset(category_names)
     assert report.total_score == sum(c.score for c in report.categories)
     assert report.total_max_score == sum(c.max_score for c in report.categories)


### PR DESCRIPTION
## 概要
PR #28 マージ後に来たレビュー指摘へ対応する追補PRです。

## 修正内容
- brittle な `assert len(report.categories) == 4` を削除
- 代わりに必須カテゴリ名（Structure/Content/Code Quality/Language）の存在確認へ変更
- 既存の合計スコア整合性チェックは維持

## 検証
- `uv run pytest` : 4 passed

## 背景
PR #28 はすでに merge 済みのため、同PRへは追加反映できず、追補PRとして提出します。

Refs: #28