### PR TITLE
fix: harden validate_skill.py section extraction for fenced headings

### DIFF
--- a/skills/skill-quality-validation/scripts/tests/test_validate_skill.py
+++ b/skills/skill-quality-validation/scripts/tests/test_validate_skill.py
@@ -118,6 +118,30 @@ invocable: true
     assert "Core Principles" not in section
 
 
+def test_get_section_content_does_not_treat_4space_fence_as_real_fence():
+    mod = _load_validator_module()
+    content = """---
+name: extraction-skill
+description: Four-space indented fence marker should be treated as code text.
+author: Tester
+invocable: true
+---
+
+## Quick Reference
+    ```
+## Summary
+- This should be treated as a real H2 boundary.
+
+## Core Principles
+- Keep fixtures small and explicit.
+"""
+    validator = mod.SkillValidator(content=content, file_path="C:\\tmp\\SKILL.md")
+    section = validator.get_section_content("Quick Reference")
+    assert section is not None
+    assert "Core Principles" not in section
+    assert "Summary" not in section
+
+
 @pytest.mark.parametrize(
     "folder_name, skill_name, body, expected_substring",
     [

--- a/skills/skill-quality-validation/scripts/validate_skill.py
+++ b/skills/skill-quality-validation/scripts/validate_skill.py
@@ -114,8 +114,8 @@ class SkillValidator:
         fence_len = 0
 
         for idx, line in enumerate(lines):
-            stripped = line.lstrip()
-            fence_match = re.match(r'^([`~]{3,})', stripped)
+            # CommonMark: fenced code blocks are recognized with up to 3 leading spaces.
+            fence_match = re.match(r'^ {0,3}([`~]{3,})', line)
             if fence_match:
                 marker = fence_match.group(1)
                 if not in_fence:


### PR DESCRIPTION
Summary: ignore H2 headings inside fenced code blocks in get_section_content; add regression test; keep existing prefix matching behavior. Verification: uv run pytest -q skills\\skill-quality-validation\\scripts\\tests\\test_validate_skill.py; uv run python skills\\skill-quality-validation\\scripts\\validate_skill.py skills\\skills-validate-skill\\SKILL.md