### PR TITLE
feat: add dotnet-access-to-oracle-migration skill

### DIFF
--- a/dotnet/dotnet-access-to-oracle-migration/SKILL.md
+++ b/dotnet/dotnet-access-to-oracle-migration/SKILL.md
@@ -141,7 +141,7 @@ ORDER BY owner, object_name;
 
 > **Values**: ニュートラル / 基礎と型
 
-> 📚 **Advanced**: SYNONYM referent resolution and multi-owner scenarios → See [references/advanced-examples.md](references/advanced-examples.md#pattern-5-advanced---synonym-resolution)
+> 📚 **Advanced**: SYNONYM referent resolution and multi-owner scenarios → See [references/advanced-examples-part2.md](references/advanced-examples-part2.md#pattern-5-advanced---synonym-resolution)
 
 ### Step 6 — Validate Column Existence
 
@@ -165,7 +165,7 @@ ORDER BY column_id;
 
 > **Values**: 基礎と型 / 継続は力
 
-> 📚 **Advanced**: Batch column verification → See [references/advanced-examples.md](references/advanced-examples.md#pattern-6-advanced---batch-column-verification)
+> 📚 **Advanced**: Batch column verification → See [references/advanced-examples-part2.md](references/advanced-examples-part2.md#pattern-6-advanced---batch-column-verification)
 
 ### Step 7 — Convert SQL Syntax (3 Rules)
 
@@ -191,7 +191,7 @@ WHERE s."ship_date" >= '202601'
 
 > **Values**: 基礎と型 / ニュートラル
 
-> 📚 **Advanced**: Multi-table JOIN conversion → See [references/advanced-examples.md](references/advanced-examples.md#pattern-7-intermediate---multi-table-join)
+> 📚 **Advanced**: Multi-table JOIN conversion → See [references/advanced-examples.md](references/advanced-examples.md)
 
 ### Step 8 — Validate with Near Equal
 
@@ -199,9 +199,8 @@ Execute converted SQL in Oracle and compare record count to Access count. Accept
 
 ```powershell
 # ✅ CORRECT — Count Oracle records and compare
-$sql = "SELECT COUNT(*) FROM SCHEMA_A.\`"production_info\`" s WHERE s.\`"ship_date\`" >= '202601'"
 $cmd = $conn.CreateCommand()
-$cmd.CommandText = $sql
+$cmd.CommandText = 'SELECT COUNT(*) FROM SCHEMA_A."production_info" s WHERE s."ship_date" >= ''202601'''
 $oracleCount = [int]$cmd.ExecuteScalar()
 $accessCount = 178  # From user
 

--- a/dotnet/dotnet-access-to-oracle-migration/references/SKILL.ja.md
+++ b/dotnet/dotnet-access-to-oracle-migration/references/SKILL.ja.md
@@ -84,6 +84,7 @@ ORA-*エラーコードを学習シグナルとして活用し、DSN・認証・
 
 ```powershell
 # ✅ 正解 — エラーハンドリング付き接続テスト
+Add-Type -Path "Oracle.ManagedDataAccess.dll"
 $conn = New-Object Oracle.ManagedDataAccess.Client.OracleConnection
 $conn.ConnectionString = "User Id=SCHEMA_A;Password=your_password;Data Source=192.0.2.10:1521/prod_service"
 
@@ -183,7 +184,7 @@ WHERE s."ship_date" >= '202601'
 ```powershell
 # ✅ 正解 — Oracleレコード数を取得して比較
 $cmd = $conn.CreateCommand()
-$cmd.CommandText = "SELECT COUNT(*) FROM SCHEMA_A.\`"production_info\`" s WHERE s.\`"ship_date\`" >= '202601'"
+$cmd.CommandText = 'SELECT COUNT(*) FROM SCHEMA_A."production_info" s WHERE s."ship_date" >= ''202601'''
 $oracleCount = [int]$cmd.ExecuteScalar()
 $accessCount = 178
 

--- a/dotnet/dotnet-access-to-oracle-migration/references/advanced-examples-part2.md
+++ b/dotnet/dotnet-access-to-oracle-migration/references/advanced-examples-part2.md
@@ -98,7 +98,7 @@ if ($missingColumns.Count -eq 0) {
 │ 5. VALIDATE COLUMNS                                             │
 │    → all_tab_columns WHERE owner='SCHEMA_B' AND table_name='...'│
 │    → Compare with Access column list                            │
-│    → ✓ All 178 columns exist                                   │
+│    → ✓ All required columns exist                               │
 └─────────────────────────────────────────────────────────────────┘
                               ↓
 ┌─────────────────────────────────────────────────────────────────┐

--- a/dotnet/dotnet-access-to-oracle-migration/references/advanced-examples.md
+++ b/dotnet/dotnet-access-to-oracle-migration/references/advanced-examples.md
@@ -20,7 +20,7 @@ foreach ($dsn in $dsnNames) {
     $tnspingOutput = tnsping $dsn 2>&1
     
     if ($tnspingOutput -match 'HOST = ([^)]+)') {
-        $host = $Matches[1]
+        $dbHost = $Matches[1]
     }
     if ($tnspingOutput -match 'PORT = ([^)]+)') {
         $port = $Matches[1]
@@ -30,7 +30,7 @@ foreach ($dsn in $dsnNames) {
     }
     
     # Build EZ Connect string
-    $ezConnect = "$host`:$port/$serviceName"
+    $ezConnect = "$dbHost`:$port/$serviceName"
     Write-Host "EZ Connect: $ezConnect" -ForegroundColor Green
 }
 ```
@@ -145,7 +145,7 @@ ORDER BY
 
 ---
 
-## Pattern 9: Advanced - Resource Disposal with using Statements
+## Pattern 10: Advanced - Resource Disposal with using Statements
 
 **Use Case**: Proper IDisposable management for Oracle connections
 
@@ -212,9 +212,4 @@ Console.WriteLine($"Retrieved {results.Rows.Count} records");
 
 **See Also**:
 - [SKILL.md](../SKILL.md) - Main skill documentation
-- [anti-patterns.md](anti-patterns.md) - Common mistakes to avoid
 - [SKILL.ja.md](SKILL.ja.md) - 日本語版
-
-**Related Files**:
-- [OracleApp/SampleDataExtractor.cs](../../../OracleApp/SampleDataExtractor.cs) - Production implementation
-- [OracleApp/BaseExtractor.cs](../../../OracleApp/BaseExtractor.cs) - Reference implementation


### PR DESCRIPTION
## 概要
dotnet-access-to-oracle-migration スキルを新規追加。
AccessデータベースクエリをOracleに移行し、.NET（C#）IOracle実装クラスを生成するための9ステップワークフロー。

## 理由
Access→Oracle移行作業の手順を形式知化し、再現可能な型として誰でも使えるようにするため。

## 変更内容
- SKILL.md（EN）: Workflow形式、9ステップ、382行、検証スコア98.3% PASS
- references/SKILL.ja.md（JA）: 構造パリティ、351行、検証スコア88.1% PASS
- references/advanced-examples.md: 本番レベルの高度な例
- references/advanced-examples-part2.md: 追加の高度な例

## 構造
- `## Workflow: Migrate Access SQL to Oracle` + `### Step N —` 形式
- Core Principles に Values 統合（基礎と型、ニュートラル、継続は力、成長の複利）
- Good Practices / Common Pitfalls / Anti-Patterns セクション完備
- Migration Checklist + Conversion Cheat Sheet

## テスト
validate_skill.py で両ファイル検証済み:
- EN: 98.3% ✅ PASS（Structure 100%, Content 100%, Code Quality 100%, Language 90%）
- JA: 88.1% ✅ PASS（全カテゴリ ≥80%）

## 関連
新規スキル追加のため、関連Issueなし
