### PR TITLE
refactor: 運用系スキルを全shihan共通管轄に整理

### DIFF
--- a/agents/dotnet-shihan.agent.md
+++ b/agents/dotnet-shihan.agent.md
@@ -106,6 +106,14 @@ tools:
 - `dotnet-marketplace-publishing` — マーケットプレイス公開
 - `dotnet-mjml-email-templates` — MJMLメールテンプレート
 
+### 共通運用スキル（skill-shihan管理、全shihan共通）
+- `git-commit-practices` — コミット規約
+- `git-initial-setup` — Git初期設定
+- `git-init-to-github` — リポジトリ作成からGitHub接続
+- `github-pr-workflow` — PR作成ワークフロー
+- `github-issue-intake` — Issue取り込み
+- `furikaeri-practice` — ふりかえり実践
+
 ---
 
 ## 品質基準（先生モードで使用）

--- a/agents/python-shihan.agent.md
+++ b/agents/python-shihan.agent.md
@@ -67,6 +67,14 @@ Pythonエコシステムの進化を追い、新しいパターンを作る。
 ### 現在
 - `python-setup-dev-environment` — Python開発環境セットアップ
 
+### 共通運用スキル（skill-shihan管理、全shihan共通）
+- `git-commit-practices` — コミット規約
+- `git-initial-setup` — Git初期設定
+- `git-init-to-github` — リポジトリ作成からGitHub接続
+- `github-pr-workflow` — PR作成ワークフロー
+- `github-issue-intake` — Issue取り込み
+- `furikaeri-practice` — ふりかえり実践
+
 ### 将来の成長領域（スキル化候補）
 - Python型注釈とmypyの実践
 - pytest パターン（fixture, parametrize, conftest設計）

--- a/agents/skill-shihan.agent.md
+++ b/agents/skill-shihan.agent.md
@@ -75,7 +75,11 @@ tools:
 - `skills-review-skill-enterprise-readiness` — エンタープライズ対応レビュー
 - `skill-quality-validation` — バリデーションスクリプト
 
-### 運用系
+### 全shihan共通管轄（運用系）
+
+以下は全shihan（dotnet/python/skill）が自ドメインの作業中に参照・使用するスキル。
+skill-shihan がオーナーとして品質管理を担当する。
+
 - `agent-batch-workflow` — バッチ操作ワークフロー
 - `furikaeri-practice` — ふりかえり実践
 - `git-commit-practices` — コミット規約


### PR DESCRIPTION
## 概要
運用系スキル（Git/GitHub/ふりかえり）の管轄を「全shihan共通管轄」として整理。

## 理由
Git/GitHub運用スキルは特定ドメインに依存しない全PJ横断の関心事。
skill-shihanのみが管轄していたため、dotnet-shihan/python-shihanから参照できなかった。
専用agentを新設するのではなく、管轄の明確化で解決する（余白の設計）。

## 変更内容
- skill-shihan: 「運用系」→「全shihan共通管轄（運用系）」に名称変更、説明追加
- dotnet-shihan: 共通運用スキルセクション追加（6スキル参照）
- python-shihan: 共通運用スキルセクション追加（6スキル参照）

## テスト
- エージェント定義ファイルの構造・内容確認済み
- ~/.copilot/agents/ へのグローバル同期完了
