### PR TITLE
docs: 配布ハブ構造整理のふりかえり記録

### DIFF
--- a/docs/furikaeri/2026-02-22-distribution-hub-shihan-jurisdiction.md
+++ b/docs/furikaeri/2026-02-22-distribution-hub-shihan-jurisdiction.md
@@ -1,0 +1,40 @@
+# KPT — 2026-02-22 配布ハブ構造整理 + shihan管轄整理
+
+## Session Story
+
+1. 新PJ開発スタート方法の調査（dotnet/python）
+2. グローバルデプロイ計画策定（~/.copilot/ への配布設計）
+3. リポジトリ構造リファクタ（.github/ → agents/ + copilot/）
+4. PR #57 作成・マージ（構造変更）
+5. main ブランチ保護フック設置（pre-commit/pre-push）
+6. Git-shihan エージェント分析 → 不採用（管轄整理で対応）
+7. PR #58 作成・マージ（全shihan共通管轄整理）
+
+## Keep
+- 配布ハブ設計が明確に — トップレベルディレクトリ = デプロイ先のマッピングが直感的
+- DRY原則の徹底 — copilot-instructions.md を単一ソースに統一
+- main保護フックの即時対応 — 問題発覚→設置→テストまで一気に完了
+- 分析ベースの判断 — git-shihan を条件表で分析し、根拠ある不採用を選択
+- ブランチワークフロー遵守 — PR #57, #58 ともに git switch -c → PR → squash-merge
+
+## Problem
+- 前回mainに直接コミットしていた（今回フック設置で修正済み）
+- フックはクローン時に再設置が必要（.git/hooks/ はGit追跡外）
+
+## Try
+- (← P) `git-initial-setup` スキル実行をクローン後の必須手順としてREADMEに明記
+- (← K) 新PJ作成時のクイックスタートガイドを将来的にドキュメント化
+
+## Priority (top 1-3)
+1. 🔴 フックはクローン時に再設置が必要（Problem）
+2. 🟡 `git-initial-setup` スキル実行をREADMEに明記（Try ← P）
+
+## Action (SMART)
+- **S**: README.mdのクローン後手順に `git-initial-setup` スキル実行を明記
+- **M**: README「セットアップ」セクションに手順が記載されている
+- **A**: README 1行追記 + 任意でIssue化
+- **R**: main直接コミット再発防止の最終防衛線
+- **T**: 次回セッション開始時に対応
+
+## Meta
+- フォーマット: KPT — このまま継続


### PR DESCRIPTION
## 概要
配布ハブ構造整理 + shihan管轄整理セッションのふりかえり（KPT）を記録。

## 理由
セッションの学びを形式知化し、次回アクション（git-initial-setup手順のREADME明記）を追跡可能にするため。

## 関連
Refs #57, #58
