### PR TITLE
feat: dotnet-skill-deploy スキル追加（対話型プロジェクトデプロイ）

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,26 @@ rsync -a --delete /mnt/c/tools/skills_repository/skills/ ~/.codex/skills/
 
 production/ や言語別Skillsは、プロジェクトの`.github/skills/`にコピーして使用します。
 
+**dotnetスキルのデプロイ（推奨: `dotnet-skill-deploy` スキル使用）**:
+
+`@dotnet-shihan` に「dotnetスキルをプロジェクトにデプロイして」と依頼すると、対話型でプロジェクト種別に応じたスキルを選択・コピーできます。
+
+手動実行する場合:
+
+```powershell
+# カテゴリ一覧を表示
+& C:\tools\skills_repository\skills\dotnet-skill-deploy\scripts\Deploy-DotnetSkills.ps1 `
+    -SourceRoot C:\tools\skills_repository\dotnet -List
+
+# WPFアプリ開発一式をデプロイ
+& C:\tools\skills_repository\skills\dotnet-skill-deploy\scripts\Deploy-DotnetSkills.ps1 `
+    -SourceRoot C:\tools\skills_repository\dotnet `
+    -Target C:\path\to\my-project `
+    -Category wpf-app
+```
+
+**productionスキルの手動コピー**:
+
 ```bash
 mkdir -p .github/skills
 cp -r /tmp/skills-repository/production/* .github/skills/

--- a/agents/dotnet-shihan.agent.md
+++ b/agents/dotnet-shihan.agent.md
@@ -106,6 +106,9 @@ tools:
 - `dotnet-marketplace-publishing` — マーケットプレイス公開
 - `dotnet-mjml-email-templates` — MJMLメールテンプレート
 
+### デプロイ・運用
+- `dotnet-skill-deploy` — dotnetスキルのプロジェクトデプロイ（カテゴリ/個別選択）
+
 ### 共通運用スキル（skill-shihan管理、全shihan共通）
 - `git-commit-practices` — コミット規約
 - `git-initial-setup` — Git初期設定

--- a/skills/dotnet-skill-deploy/SKILL.md
+++ b/skills/dotnet-skill-deploy/SKILL.md
@@ -1,0 +1,274 @@
+---
+name: dotnet-skill-deploy
+description: >
+  Deploy selected dotnet skills to a project's .github/skills/ directory.
+  Use when setting up a new .NET project, onboarding a team to dotnet skills,
+  or updating project-level skills from the skills_repository.
+allowed-tools:
+  - powershell
+metadata:
+  author: RyoMurakami1983
+  tags: [dotnet, deployment, skills, project-setup, automation]
+  invocable: false
+---
+
+# Deploy Dotnet Skills to Project
+
+Interactive workflow for deploying selected dotnet skills from `skills_repository/dotnet/` to a target project's `.github/skills/` directory. The agent guides the user through project analysis, category selection, and execution via `Deploy-DotnetSkills.ps1`.
+
+## When to Use This Skill
+
+Use this skill when:
+- Setting up a new .NET project that needs relevant dotnet skills deployed
+- Onboarding a team member who needs project-level coding standards
+- Updating project-level skills from the latest skills_repository
+- Responding to "dotnet skills をプロジェクトに追加して" or "deploy skills to my project"
+- Starting a new WPF, Blazor, or class library project with standardized patterns
+
+## Related Skills
+
+- **`dotnet-modern-csharp-coding-standards`** — One of the foundation skills frequently deployed
+- **`dotnet-wpf-mvvm-patterns`** — WPF MVVM foundation skill
+- **`dotnet-project-structure`** — Project structure skill
+- **`git-initial-setup`** — Often used alongside skill deployment for new projects
+
+---
+
+## Dependencies
+
+- PowerShell 5.1+ (Windows)
+- `skills_repository` cloned locally (typically at `C:\tools\skills_repository`)
+
+## Core Principles
+
+1. **Selective Deployment** — Copy only relevant skills to avoid agent context noise (余白の設計)
+2. **Category-Driven Selection** — Use predefined categories aligned with `dotnet-shihan` jurisdiction for consistent grouping (基礎と型)
+3. **Idempotent Operations** — Safe to re-run; existing skills are skipped unless `-Force` is specified (継続は力)
+4. **Transparency First** — Always show what will be deployed before executing; support `-WhatIf` for dry runs (ニュートラルな視点)
+
+---
+
+## Workflow: Deploy Dotnet Skills
+
+### Step 1 — Confirm Project Information
+
+Gather deployment context from the user:
+
+1. **Target project path**: Confirm where `.github/skills/` should be created
+2. **Project type**: Identify the project category to recommend skills
+
+```
+Questions to ask:
+- "Which project should I deploy skills to? (provide the project root path)"
+- "What type of .NET project is this?"
+  Options: WPF application, Class library, Blazor app, Console app, Other
+```
+
+**Output**: Target path and project type confirmed.
+
+> **Values**: ニュートラルな視点（先入観なく、プロジェクトの実態に合わせる）
+
+### Step 2 — Recommend Categories and Skills
+
+Based on the project type, recommend appropriate skill categories:
+
+| Project Type | Recommended Categories | Typical Skill Count |
+|-------------|----------------------|-------------------|
+| WPF Application | `wpf-app` (composite) | 15 |
+| Class Library | `foundation` + `data` | 8 |
+| Blazor App | `foundation` + `testing` (playwright) | 12 |
+| Console App | `foundation` | 5 |
+| Full Stack | `all` | 31 |
+
+**Run `-List` to show all options**:
+
+```powershell
+& "<skills_repository>\skills\dotnet-skill-deploy\scripts\Deploy-DotnetSkills.ps1" `
+    -SourceRoot "<skills_repository>\dotnet" `
+    -List
+```
+
+**Available categories** (aligned with `dotnet-shihan.agent.md`):
+
+| Category | Count | Description |
+|----------|-------|-------------|
+| `foundation` | 5 | Technical foundation (modern-csharp, type-design, project-structure, slopwatch, api-design) |
+| `data` | 3 | Data & persistence (efcore, database-performance, serialization) |
+| `testing` | 7 | Concurrency, testing & CI (concurrency, testcontainers, snapshot-testing, verify-email, crap-analysis, playwright-blazor, playwright-ci-caching) |
+| `wpf` | 11 | WPF & desktop (mvvm, secure-config, oracle, dify, UI components, matching) |
+| `infra` | 6 | Infrastructure & packages (DI, configuration, local-tools, package-management, marketplace, mjml) |
+| `wpf-app` | 15 | **Composite**: foundation subset + wpf + infra subset |
+| `all` | 31 | All dotnet skills |
+
+Present the recommendation and let the user adjust:
+
+```
+"For a WPF application, I recommend the 'wpf-app' category (15 skills).
+This includes coding standards, MVVM patterns, secure config, and all WPF UI components.
+Would you like to proceed, or adjust the selection?"
+```
+
+**Output**: Selected categories and/or individual skills confirmed.
+
+> **Values**: 基礎と型（カテゴリが選択の型を提供）/ 成長の複利（必要なスキルだけで精度向上）
+
+### Step 3 — Execute Deployment
+
+Run the deployment script with confirmed parameters:
+
+**Category deployment**:
+
+```powershell
+# Why: category deployment is the recommended default — ensures consistent skill sets
+& "<skills_repository>\skills\dotnet-skill-deploy\scripts\Deploy-DotnetSkills.ps1" `
+    -SourceRoot "<skills_repository>\dotnet" `
+    -Target "<project_path>" `
+    -Category <selected_category>
+```
+
+**Individual skills deployment**:
+
+```powershell
+# Why: use individual selection when only specific skills are needed
+& "<skills_repository>\skills\dotnet-skill-deploy\scripts\Deploy-DotnetSkills.ps1" `
+    -SourceRoot "<skills_repository>\dotnet" `
+    -Target "<project_path>" `
+    -Skills <skill1>,<skill2>,<skill3>
+```
+
+**For updates (overwrite existing)**:
+
+```powershell
+# Why: -Force ensures latest skill versions replace outdated copies
+& "<skills_repository>\skills\dotnet-skill-deploy\scripts\Deploy-DotnetSkills.ps1" `
+    -SourceRoot "<skills_repository>\dotnet" `
+    -Target "<project_path>" `
+    -Category <selected_category> `
+    -Force
+```
+
+**Important**: Always run with `-WhatIf` first if the user wants to preview:
+
+```powershell
+# Why: preview prevents accidental overwrites and confirms scope
+& "<skills_repository>\skills\dotnet-skill-deploy\scripts\Deploy-DotnetSkills.ps1" `
+    -SourceRoot "<skills_repository>\dotnet" `
+    -Target "<project_path>" `
+    -Category <selected_category> `
+    -WhatIf
+```
+
+**Output**: Skills copied to `<project_path>\.github\skills\`.
+
+> **Values**: 継続は力（繰り返し実行可能な自動化）
+
+### Step 4 — Verify and Guide Next Steps
+
+After deployment, verify and provide guidance:
+
+1. **Verify deployment**: List the deployed skills directory
+
+```powershell
+Get-ChildItem "<project_path>\.github\skills" -Directory | Select-Object Name
+```
+
+2. **Advise on git tracking**: The user decides whether to git-track the deployed skills
+
+```
+"Skills have been deployed to .github/skills/.
+These skills are NOT git-tracked by default.
+If you want to track them in your project repository, run:
+  git add .github/skills/
+  git commit -m 'feat: add dotnet skills for project-level guidance'"
+```
+
+3. **Suggest next steps**:
+   - Review deployed skills in the project
+   - Run `git-initial-setup` if this is a new repository
+   - Start coding with `@dotnet-shihan` referencing the deployed skills
+
+**Output**: Deployment confirmed with actionable next steps.
+
+> **Values**: 成長の複利（デプロイ後のアクション案内で学習を加速）
+
+---
+
+## Best Practices
+
+- ✅ **Start with categories, refine with individual skills** — Use `-Category` for bulk, `-Skills` to add extras. Why: categories provide the right defaults for 80% of cases.
+- ✅ **Preview first** — Always offer `-WhatIf` before actual deployment. Why: transparency builds trust and prevents accidental overwrites.
+- ✅ **Deploy fewer, not more** — Extra skills add context noise for the agent. Why: Copilot's context window is finite; irrelevant skills dilute relevant guidance.
+- ✅ **Update periodically** — Re-run with `-Force` when skills_repository is updated. Why: skills evolve with new patterns and best practices.
+- ✅ **Match project type** — A WPF app doesn't need Blazor/Playwright skills. Why: precision > coverage for agent-assisted development.
+
+## Anti-Patterns
+
+- ❌ **Deploy `all` by default** → Fix: select relevant categories based on project type
+- ❌ **Skip verification** → Fix: always confirm deployed skills in Step 4
+- ❌ **Hardcode paths** → Fix: use `-SourceRoot` and `-Target` parameters
+- ❌ **Forget `-Force` on updates** → Fix: explicitly add `-Force` when updating existing skills
+
+## Common Pitfalls
+
+| Pitfall | Symptom | Fix |
+|---------|---------|-----|
+| Wrong `-SourceRoot` path | "SourceRoot not found" error | Verify `skills_repository\dotnet` path exists |
+| Missing `.github\skills\` directory | No skills visible to agent | Script creates it automatically; verify `-Target` path |
+| Deploying without `-WhatIf` first | Unexpected files in project | Always preview first, then deploy |
+| Mixing categories with overlap | Duplicate copy attempts | Script deduplicates automatically; no action needed |
+
+---
+
+## Quick Reference
+
+```
+# List available categories and skills
+Deploy-DotnetSkills.ps1 -SourceRoot <dotnet_path> -List
+
+# Deploy by category (preview first)
+Deploy-DotnetSkills.ps1 -SourceRoot <dotnet_path> -Target <project> -Category wpf-app -WhatIf
+Deploy-DotnetSkills.ps1 -SourceRoot <dotnet_path> -Target <project> -Category wpf-app
+
+# Deploy individual skills
+Deploy-DotnetSkills.ps1 -SourceRoot <dotnet_path> -Target <project> -Skills skill1,skill2
+
+# Update existing skills
+Deploy-DotnetSkills.ps1 -SourceRoot <dotnet_path> -Target <project> -Category wpf-app -Force
+```
+
+---
+
+## Script Reference
+
+The deployment script is located at `scripts/Deploy-DotnetSkills.ps1`.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `-SourceRoot` | string | Yes | Path to dotnet skills source directory |
+| `-Target` | string | For deploy | Path to target project root |
+| `-Category` | string | For deploy* | Category name: foundation, data, testing, wpf, infra, wpf-app, all |
+| `-Skills` | string[] | For deploy* | Comma-separated skill names |
+| `-List` | switch | No | Show available categories and skills |
+| `-Force` | switch | No | Overwrite existing skills |
+| `-WhatIf` | switch | No | Preview without copying |
+
+\* At least one of `-Category` or `-Skills` is required for deployment.
+
+---
+
+## FAQ
+
+**Q: Where should skills_repository be cloned?**
+A: The recommended location is `C:\tools\skills_repository`. The `-SourceRoot` parameter points to its `dotnet/` subdirectory.
+
+**Q: Can I combine `-Category` and `-Skills`?**
+A: Yes. The script merges both selections (deduplicates automatically).
+
+**Q: What happens if a skill already exists in the target?**
+A: Without `-Force`, it's skipped. With `-Force`, it's overwritten (deleted and re-copied).
+
+**Q: Are copied skills git-tracked?**
+A: Not automatically. The user decides whether to `git add` them.
+
+**Q: Can I deploy production/ skills too?**
+A: This skill is dotnet-specific. For production skills, copy them manually: `Copy-Item -Recurse production\* .github\skills\`.

--- a/skills/dotnet-skill-deploy/references/SKILL.ja.md
+++ b/skills/dotnet-skill-deploy/references/SKILL.ja.md
@@ -1,0 +1,245 @@
+---
+name: dotnet-skill-deploy
+description: >
+  選択したdotnetスキルをプロジェクトの .github/skills/ にデプロイする。
+  新規.NETプロジェクトのセットアップ時、チームへのスキル展開時、
+  またはskills_repositoryからのスキル更新時に使用。
+allowed-tools:
+  - powershell
+metadata:
+  author: RyoMurakami1983
+  tags: [dotnet, deployment, skills, project-setup, automation]
+  invocable: false
+---
+
+# dotnetスキルをプロジェクトにデプロイする
+
+`skills_repository/dotnet/` から選択したdotnetスキルを、対象プロジェクトの `.github/skills/` にデプロイする対話型ワークフロー。エージェントがプロジェクト分析、カテゴリ選択、実行を `Deploy-DotnetSkills.ps1` 経由でガイドする。
+
+## When to Use This Skill
+
+以下の場面で使用：
+- 新規.NETプロジェクトのセットアップ時に関連スキルをデプロイしたい
+- チームメンバーのオンボーディングでプロジェクトレベルのコーディング標準が必要
+- skills_repositoryの最新版でプロジェクトレベルのスキルを更新したい
+- 「dotnet skills をプロジェクトに追加して」と依頼された
+- 新規WPF、Blazor、クラスライブラリプロジェクトを開始する
+
+## Related Skills
+
+- **`dotnet-modern-csharp-coding-standards`** — 頻繁にデプロイされる基盤スキル
+- **`dotnet-wpf-mvvm-patterns`** — WPF MVVM基盤スキル
+- **`dotnet-project-structure`** — プロジェクト構造スキル
+- **`git-initial-setup`** — 新規プロジェクトでスキルデプロイと併用
+
+---
+
+## Dependencies
+
+- PowerShell 5.1+（Windows）
+- `skills_repository` がローカルにクローン済み（通常 `C:\tools\skills_repository`）
+
+## Core Principles
+
+1. **選択的デプロイ** — 関連するスキルのみコピーし、エージェントのコンテキストノイズを回避（余白の設計）。なぜ？ — 不要なスキルがプロジェクトにあると、Copilotエージェントのコンテキストウィンドウに入り、関連しないパターンを参照してしまう。WPFプロジェクトにBlazorスキルは不要。
+
+2. **カテゴリ駆動選択** — `dotnet-shihan` 管轄に整合したカテゴリで一貫したグルーピング（基礎と型）。なぜ？ — 31スキルを一つずつ選ぶのは非効率。dotnet-shihan.agent.mdの分類と同じカテゴリを使うことで、エージェントとユーザーの間に共通言語が生まれる。
+
+3. **べき等な操作** — 安全に再実行可能。既存スキルは `-Force` 指定時のみ上書き（継続は力）。なぜ？ — 誤って実行しても既存のスキルを壊さない。更新時は明示的に `-Force` を使うことで意図を明確にする。
+
+4. **透明性優先** — 実行前に何がデプロイされるか常に表示。`-WhatIf` でドライラン対応（ニュートラルな視点）。なぜ？ — 「何が起こるか分からない」ツールは使われない。事前プレビューが信頼を生む。
+
+---
+
+## Workflow: dotnetスキルのデプロイ
+
+### Step 1 — プロジェクト情報の確認
+
+デプロイのコンテキストをユーザーから収集：
+
+1. **ターゲットプロジェクトパス**: `.github/skills/` を作成する場所を確認
+2. **プロジェクトの種類**: スキル推奨のためのプロジェクトカテゴリを特定
+
+```
+質問例:
+- 「どのプロジェクトにスキルをデプロイしますか？（プロジェクトのルートパスを教えてください）」
+- 「このプロジェクトの種類は？」
+  選択肢: WPFアプリケーション、クラスライブラリ、Blazorアプリ、コンソールアプリ、その他
+```
+
+**出力**: ターゲットパスとプロジェクト種別が確定。
+
+> **Values**: ニュートラルな視点（先入観なく、プロジェクトの実態に合わせる）
+
+### Step 2 — カテゴリ・スキルの提案
+
+プロジェクト種別に基づき適切なスキルカテゴリを推奨：
+
+| プロジェクト種別 | 推奨カテゴリ | 概算スキル数 |
+|---------------|------------|------------|
+| WPFアプリケーション | `wpf-app`（複合） | 15 |
+| クラスライブラリ | `foundation` + `data` | 8 |
+| Blazorアプリ | `foundation` + `testing`（playwright） | 12 |
+| コンソールアプリ | `foundation` | 5 |
+| フルスタック | `all` | 31 |
+
+**`-List` で全オプションを表示**:
+
+```powershell
+& "<skills_repository>\skills\dotnet-skill-deploy\scripts\Deploy-DotnetSkills.ps1" `
+    -SourceRoot "<skills_repository>\dotnet" `
+    -List
+```
+
+**利用可能なカテゴリ**（`dotnet-shihan.agent.md` と整合）:
+
+| カテゴリ | 数 | 説明 |
+|---------|---|------|
+| `foundation` | 5 | 技術基盤（modern-csharp, type-design, project-structure, slopwatch, api-design） |
+| `data` | 3 | データ・永続化（efcore, database-performance, serialization） |
+| `testing` | 7 | 並行・テスト・CI（concurrency, testcontainers, snapshot-testing, verify-email, crap-analysis, playwright-blazor, playwright-ci-caching） |
+| `wpf` | 11 | WPF・デスクトップ（mvvm, secure-config, oracle, dify, UIコンポーネント, マッチング） |
+| `infra` | 6 | インフラ・パッケージ（DI, configuration, local-tools, package-management, marketplace, mjml） |
+| `wpf-app` | 15 | **複合**: foundation一部 + wpf + infra一部 |
+| `all` | 31 | 全dotnetスキル |
+
+推奨を提示し、ユーザーに調整を依頼：
+
+```
+「WPFアプリケーションには 'wpf-app' カテゴリ（15スキル）を推奨します。
+コーディング標準、MVVMパターン、セキュア設定、全WPF UIコンポーネントが含まれます。
+このまま進めますか？カスタマイズしますか？」
+```
+
+**出力**: 選択されたカテゴリ・個別スキルが確定。
+
+> **Values**: 基礎と型（カテゴリが選択の型を提供）/ 成長の複利（必要なスキルだけで精度向上）
+
+### Step 3 — デプロイ実行
+
+確定したパラメータでデプロイスクリプトを実行：
+
+**カテゴリデプロイ**:
+
+```powershell
+& "<skills_repository>\skills\dotnet-skill-deploy\scripts\Deploy-DotnetSkills.ps1" `
+    -SourceRoot "<skills_repository>\dotnet" `
+    -Target "<project_path>" `
+    -Category <selected_category>
+```
+
+**個別スキルデプロイ**:
+
+```powershell
+& "<skills_repository>\skills\dotnet-skill-deploy\scripts\Deploy-DotnetSkills.ps1" `
+    -SourceRoot "<skills_repository>\dotnet" `
+    -Target "<project_path>" `
+    -Skills <skill1>,<skill2>,<skill3>
+```
+
+**更新（既存を上書き）**:
+
+```powershell
+& "<skills_repository>\skills\dotnet-skill-deploy\scripts\Deploy-DotnetSkills.ps1" `
+    -SourceRoot "<skills_repository>\dotnet" `
+    -Target "<project_path>" `
+    -Category <selected_category> `
+    -Force
+```
+
+**重要**: プレビュー希望時は先に `-WhatIf` を実行：
+
+```powershell
+& "<skills_repository>\skills\dotnet-skill-deploy\scripts\Deploy-DotnetSkills.ps1" `
+    -SourceRoot "<skills_repository>\dotnet" `
+    -Target "<project_path>" `
+    -Category <selected_category> `
+    -WhatIf
+```
+
+**出力**: スキルが `<project_path>\.github\skills\` にコピー完了。
+
+> **Values**: 継続は力（繰り返し実行可能な自動化）
+
+### Step 4 — 確認と次のステップ案内
+
+デプロイ後の確認とガイダンス：
+
+1. **デプロイ確認**: デプロイされたスキルディレクトリを一覧表示
+
+```powershell
+Get-ChildItem "<project_path>\.github\skills" -Directory | Select-Object Name
+```
+
+2. **Git管理のアドバイス**: デプロイされたスキルのGit追跡はユーザーが決定
+
+```
+「スキルが .github/skills/ にデプロイされました。
+デフォルトではGit追跡されていません。
+プロジェクトリポジトリで管理する場合は以下を実行:
+  git add .github/skills/
+  git commit -m 'feat: add dotnet skills for project-level guidance'」
+```
+
+3. **次のステップ提案**:
+   - プロジェクト内のデプロイ済みスキルを確認
+   - 新規リポジトリなら `git-initial-setup` を実行
+   - `@dotnet-shihan` でデプロイ済みスキルを参照しながらコーディング開始
+
+**出力**: デプロイ確認と具体的な次のアクション。
+
+> **Values**: 成長の複利（デプロイ後のアクション案内で学習を加速）
+
+---
+
+## Best Practices
+
+- ✅ **カテゴリで始め、個別スキルで微調整** — `-Category` で一括、`-Skills` で追加
+- ✅ **まずプレビュー** — 実デプロイ前に必ず `-WhatIf` を提案
+- ✅ **少なく、多くなく** — 余分なスキルはエージェントのコンテキストノイズ
+- ✅ **定期的に更新** — skills_repository更新時に `-Force` で再実行
+- ✅ **プロジェクト種別に合わせる** — WPFアプリにBlazor/Playwrightスキルは不要
+
+## Anti-Patterns
+
+- ❌ **デフォルトで `all` をデプロイ** — 不要なコンテキストノイズを追加。関連カテゴリを選択
+- ❌ **確認をスキップ** — Step 4で必ずデプロイ結果を確認
+- ❌ **パスをハードコード** — `-SourceRoot` と `-Target` パラメータを使い、仮定しない
+- ❌ **更新時の `-Force` 忘れ** — なしでは既存スキルがサイレントにスキップされる
+
+---
+
+## スクリプトリファレンス
+
+デプロイスクリプトは `scripts/Deploy-DotnetSkills.ps1` に配置。
+
+| パラメータ | 型 | 必須 | 説明 |
+|-----------|---|------|------|
+| `-SourceRoot` | string | Yes | dotnetスキルのソースディレクトリパス |
+| `-Target` | string | デプロイ時 | ターゲットプロジェクトのルートパス |
+| `-Category` | string | デプロイ時* | カテゴリ名: foundation, data, testing, wpf, infra, wpf-app, all |
+| `-Skills` | string[] | デプロイ時* | カンマ区切りのスキル名 |
+| `-List` | switch | No | 利用可能なカテゴリとスキルを表示 |
+| `-Force` | switch | No | 既存スキルを上書き |
+| `-WhatIf` | switch | No | コピーせずプレビュー |
+
+\* デプロイには `-Category` または `-Skills` のいずれかが必要。
+
+---
+
+## FAQ
+
+**Q: skills_repositoryはどこにクローンすべき？**
+A: 推奨場所は `C:\tools\skills_repository`。`-SourceRoot` パラメータでその `dotnet/` サブディレクトリを指定。
+
+**Q: `-Category` と `-Skills` を組み合わせられる？**
+A: はい。スクリプトは両方の選択をマージ（重複自動排除）。
+
+**Q: 既存スキルがターゲットにある場合は？**
+A: `-Force` なしではスキップ。`-Force` ありでは上書き（削除して再コピー）。
+
+**Q: コピーされたスキルはGit管理される？**
+A: 自動的には管理されない。ユーザーが `git add` するかどうかを決定。
+
+**Q: production/ スキルもデプロイできる？**
+A: このスキルはdotnet専用。productionスキルは手動コピー: `Copy-Item -Recurse production\* .github\skills\`。

--- a/skills/dotnet-skill-deploy/scripts/Deploy-DotnetSkills.ps1
+++ b/skills/dotnet-skill-deploy/scripts/Deploy-DotnetSkills.ps1
@@ -1,0 +1,284 @@
+<#
+.SYNOPSIS
+    Deploy dotnet skills from skills_repository to a target project.
+
+.DESCRIPTION
+    Copies selected dotnet skills to a project's .github/skills/ directory.
+    Skills can be selected by category or individually by name.
+
+.PARAMETER SourceRoot
+    Path to the dotnet skills source directory (e.g., C:\tools\skills_repository\dotnet).
+
+.PARAMETER Target
+    Path to the target project root. Skills are copied to <Target>\.github\skills\.
+
+.PARAMETER Category
+    Deploy all skills in a category. Valid: foundation, data, testing, wpf, infra, wpf-app, all.
+
+.PARAMETER Skills
+    Comma-separated list of individual skill names to deploy.
+
+.PARAMETER List
+    Show available categories and skills, then exit.
+
+.PARAMETER Force
+    Overwrite existing skills in the target directory.
+
+.PARAMETER WhatIf
+    Show what would be copied without actually copying.
+
+.EXAMPLE
+    .\Deploy-DotnetSkills.ps1 -SourceRoot C:\tools\skills_repository\dotnet -List
+
+.EXAMPLE
+    .\Deploy-DotnetSkills.ps1 -SourceRoot C:\tools\skills_repository\dotnet -Target C:\my-project -Category wpf-app
+
+.EXAMPLE
+    .\Deploy-DotnetSkills.ps1 -SourceRoot C:\tools\skills_repository\dotnet -Target C:\my-project -Skills dotnet-wpf-secure-config,dotnet-oracle-wpf-integration
+#>
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    [Parameter(Mandatory)]
+    [string]$SourceRoot,
+
+    [Parameter()]
+    [string]$Target,
+
+    [Parameter()]
+    [ValidateSet('foundation', 'data', 'testing', 'wpf', 'infra', 'wpf-app', 'all')]
+    [string]$Category,
+
+    [Parameter()]
+    [string[]]$Skills,
+
+    [switch]$List,
+
+    [switch]$Force
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# --- Category Definitions (aligned with dotnet-shihan.agent.md) ---
+
+$CategoryMap = [ordered]@{
+    'foundation' = @(
+        'dotnet-modern-csharp-coding-standards'
+        'dotnet-type-design-performance'
+        'dotnet-project-structure'
+        'dotnet-slopwatch'
+        'dotnet-csharp-api-design'
+    )
+    'data' = @(
+        'dotnet-efcore-patterns'
+        'dotnet-database-performance'
+        'dotnet-serialization'
+    )
+    'testing' = @(
+        'dotnet-csharp-concurrency-patterns'
+        'dotnet-testcontainers'
+        'dotnet-snapshot-testing'
+        'dotnet-verify-email-snapshots'
+        'dotnet-crap-analysis'
+        'dotnet-playwright-blazor'
+        'dotnet-playwright-ci-caching'
+    )
+    'wpf' = @(
+        'dotnet-wpf-mvvm-patterns'
+        'dotnet-wpf-secure-config'
+        'dotnet-oracle-wpf-integration'
+        'dotnet-wpf-dify-api-integration'
+        'dotnet-wpf-comparison-view'
+        'dotnet-wpf-employee-input'
+        'dotnet-wpf-pdf-preview'
+        'dotnet-wpf-ocr-parameter-input'
+        'dotnet-ocr-matching-workflow'
+        'dotnet-generic-matching'
+        'dotnet-access-to-oracle-migration'
+    )
+    'infra' = @(
+        'dotnet-extensions-dependency-injection'
+        'dotnet-extensions-configuration'
+        'dotnet-local-tools'
+        'dotnet-package-management'
+        'dotnet-marketplace-publishing'
+        'dotnet-mjml-email-templates'
+    )
+}
+
+# Composite category: wpf-app = foundation subset + wpf + infra subset
+$CategoryMap['wpf-app'] = @(
+    'dotnet-modern-csharp-coding-standards'
+    'dotnet-project-structure'
+) + $CategoryMap['wpf'] + @(
+    'dotnet-extensions-dependency-injection'
+    'dotnet-extensions-configuration'
+)
+
+# --- Validation ---
+
+if (-not (Test-Path $SourceRoot -PathType Container)) {
+    Write-Error "SourceRoot not found: $SourceRoot"
+    exit 1
+}
+
+# Discover all available skills from the source directory
+$AvailableSkills = Get-ChildItem -Path $SourceRoot -Directory |
+    Where-Object { Test-Path (Join-Path $_.FullName 'SKILL.md') } |
+    Select-Object -ExpandProperty Name |
+    Sort-Object
+
+# --- List Mode ---
+
+if ($List) {
+    Write-Host "`n=== Available Dotnet Skill Categories ===" -ForegroundColor Cyan
+    Write-Host ""
+
+    foreach ($cat in $CategoryMap.Keys) {
+        $skills = $CategoryMap[$cat]
+        $label = switch ($cat) {
+            'foundation' { '技術基盤 (Technical Foundation)' }
+            'data'       { 'データ・永続化 (Data & Persistence)' }
+            'testing'    { '並行・テスト・CI (Concurrency, Testing & CI)' }
+            'wpf'        { 'WPF・デスクトップ (WPF & Desktop)' }
+            'infra'      { 'インフラ・パッケージ (Infrastructure & Packages)' }
+            'wpf-app'    { '【複合】WPFアプリ開発一式 (WPF App Development Bundle)' }
+            default      { $cat }
+        }
+        Write-Host "  $cat ($($skills.Count) skills) — $label" -ForegroundColor Yellow
+        foreach ($s in $skills) {
+            $marker = if ($AvailableSkills -contains $s) { '  ✓' } else { '  ✗' }
+            $color = if ($AvailableSkills -contains $s) { 'Green' } else { 'Red' }
+            Write-Host "    $marker $s" -ForegroundColor $color
+        }
+        Write-Host ""
+    }
+
+    # Show uncategorized skills
+    $allCategorized = @($CategoryMap.Values | ForEach-Object { $_ } | Sort-Object -Unique)
+    $uncategorized = @($AvailableSkills | Where-Object { $_ -notin $allCategorized })
+    if ($uncategorized.Count -gt 0) {
+        Write-Host "  uncategorized ($($uncategorized.Count) skills)" -ForegroundColor DarkYellow
+        foreach ($s in $uncategorized) {
+            Write-Host "    ✓ $s" -ForegroundColor DarkGreen
+        }
+        Write-Host ""
+    }
+
+    Write-Host "Total available: $($AvailableSkills.Count) skills" -ForegroundColor Cyan
+    Write-Host ""
+    exit 0
+}
+
+# --- Resolve Target Skills ---
+
+if (-not $Target) {
+    Write-Error "Target is required when not using -List. Specify -Target <project-path>."
+    exit 1
+}
+
+if (-not $Category -and -not $Skills) {
+    Write-Error "Specify -Category or -Skills to select which skills to deploy."
+    exit 1
+}
+
+$targetSkills = @()
+
+if ($Category) {
+    if ($Category -eq 'all') {
+        $targetSkills = @($AvailableSkills)
+    }
+    else {
+        $targetSkills = @($CategoryMap[$Category])
+    }
+}
+
+if ($Skills) {
+    $targetSkills = @(($targetSkills + $Skills) | Sort-Object -Unique)
+}
+
+# Validate all requested skills exist
+$invalidSkills = @($targetSkills | Where-Object { $_ -notin $AvailableSkills })
+if ($invalidSkills.Count -gt 0) {
+    Write-Error "Skills not found in source: $($invalidSkills -join ', ')"
+    exit 1
+}
+
+# --- Deploy ---
+
+$destBase = Join-Path $Target '.github' 'skills'
+
+$copied = @()
+$skipped = @()
+$overwritten = @()
+
+foreach ($skillName in $targetSkills) {
+    $srcPath = Join-Path $SourceRoot $skillName
+    $destPath = Join-Path $destBase $skillName
+    $exists = Test-Path $destPath
+
+    if ($exists -and -not $Force) {
+        $skipped += $skillName
+        if ($WhatIfPreference) {
+            Write-Host "  SKIP  $skillName (already exists, use -Force to overwrite)" -ForegroundColor DarkYellow
+        }
+        continue
+    }
+
+    if ($WhatIfPreference) {
+        $action = if ($exists) { 'OVERWRITE' } else { 'COPY' }
+        Write-Host "  $action  $skillName -> $destPath" -ForegroundColor Cyan
+        if ($exists) { $overwritten += $skillName } else { $copied += $skillName }
+        continue
+    }
+
+    if ($PSCmdlet.ShouldProcess($destPath, "Deploy skill '$skillName'")) {
+        if ($exists) {
+            Remove-Item -Path $destPath -Recurse -Force
+            $overwritten += $skillName
+        }
+        else {
+            $copied += $skillName
+        }
+
+        # Ensure parent directory exists
+        $parentDir = Split-Path $destPath -Parent
+        if (-not (Test-Path $parentDir)) {
+            New-Item -ItemType Directory -Path $parentDir -Force | Out-Null
+        }
+
+        Copy-Item -Path $srcPath -Destination $destPath -Recurse
+    }
+}
+
+# --- Summary ---
+
+Write-Host "`n=== Deploy Summary ===" -ForegroundColor Cyan
+Write-Host "  Source:  $SourceRoot"
+Write-Host "  Target:  $destBase"
+if ($Category) { Write-Host "  Category: $Category" }
+Write-Host ""
+
+if ($copied.Count -gt 0) {
+    Write-Host "  Copied ($($copied.Count)):" -ForegroundColor Green
+    foreach ($s in $copied) { Write-Host "    + $s" -ForegroundColor Green }
+}
+
+if ($overwritten.Count -gt 0) {
+    Write-Host "  Overwritten ($($overwritten.Count)):" -ForegroundColor Yellow
+    foreach ($s in $overwritten) { Write-Host "    ~ $s" -ForegroundColor Yellow }
+}
+
+if ($skipped.Count -gt 0) {
+    Write-Host "  Skipped ($($skipped.Count)):" -ForegroundColor DarkYellow
+    foreach ($s in $skipped) { Write-Host "    - $s (already exists)" -ForegroundColor DarkYellow }
+}
+
+$totalActions = $copied.Count + $overwritten.Count
+Write-Host "`n  Total deployed: $totalActions skill(s)" -ForegroundColor Cyan
+
+if ($WhatIfPreference) {
+    Write-Host "  (Dry run — no files were copied)" -ForegroundColor Magenta
+}
+
+Write-Host ""


### PR DESCRIPTION
## 概要
dotnetスキルをプロジェクトの `.github/skills/` に系統立ててデプロイするための対話型スキルとPowerShellスクリプトを追加。

## 理由
現状、dotnet/配下の31スキルをプロジェクトにコピーする手段が手動コピペしかなく、以下の問題があった：
- どのスキルが必要か分かりにくい
- 不要なスキルをコピーするとCopilot Agentの精度が低下
- チームメンバーへの展開が属人的

## 変更内容
- `skills/dotnet-skill-deploy/SKILL.md` — 4ステップ対話型ワークフロー（95%検証スコア）
- `skills/dotnet-skill-deploy/references/SKILL.ja.md` — 日本語版（Why詳細説明付き）
- `skills/dotnet-skill-deploy/scripts/Deploy-DotnetSkills.ps1` — 実行スクリプト
  - `-List`: カテゴリ・スキル一覧表示
  - `-Category`: カテゴリ指定デプロイ（foundation/data/testing/wpf/infra/wpf-app/all）
  - `-Skills`: 個別スキル指定デプロイ
  - `-WhatIf`: ドライラン
  - `-Force`: 既存スキル上書き
- `agents/dotnet-shihan.agent.md` — 管轄スキルに追加
- `README.md` — プロジェクトインストールセクション更新

## テスト
全パターンの動作確認済み：
- -List表示、-WhatIfドライラン、実コピー、スキップ動作、-Force上書き、エラーハンドリング
- validate_skill.py: 95.0% (Structure 100%, Content 90%, Code 100%, Language 90%)

## 関連
N/A（新規機能）
