### PR TITLE
feat(dotnet-slopwatch): add SLOP-xxx architectural anti-pattern catalog

### DIFF
--- a/agents/dotnet-shihan.agent.md
+++ b/agents/dotnet-shihan.agent.md
@@ -121,6 +121,11 @@ tools:
 
 ## 品質基準（先生モードで使用）
 
+### 初動チェック（slopwatch）
+- プロジェクトに `.config/dotnet-tools.json` がある場合: `dotnet tool restore && dotnet tool update slopwatch.cmd --local`
+- ない場合: `dotnet tool update -g slopwatch.cmd`
+- 更新後に `slopwatch --version` で確認
+
 ### モダンC#（.NET 8+）
 - `record` 型を不変データに使用
 - パターンマッチング（`is`, `switch` 式）を活用

--- a/dotnet/dotnet-slopwatch/SKILL.md
+++ b/dotnet/dotnet-slopwatch/SKILL.md
@@ -8,7 +8,7 @@ description: >
 metadata:
   author: RyoMurakami1983
   tags: [dotnet, quality, llm, anti-cheat, slopwatch]
-  invocable: true
+  invocable: false
 ---
 
 # Slopwatch: LLM Anti-Cheat for .NET
@@ -59,7 +59,7 @@ Add to `.config/dotnet-tools.json` as a local tool:
   "isRoot": true,
   "tools": {
     "slopwatch.cmd": {
-      "version": "0.2.0",
+      "version": "0.3.4",  // check latest: dotnet tool search slopwatch
       "commands": ["slopwatch"],
       "rollForward": false
     }
@@ -113,9 +113,11 @@ When Slopwatch flags an issue, **do not ignore it**:
 
 > **Values**: 基礎と型（根本原因の修正が型）
 
-### Step 4 — Configure Claude Code Hook
+### Step 4 — Integrate with AI Coding Assistant
 
-Add Slopwatch as a post-edit hook in `.claude/settings.json`:
+#### 4a: Automatic Hook (Claude Code)
+
+Add Slopwatch as a post-edit hook in `.claude/settings.json`. The `--hook` flag analyzes only git-dirty files, outputs errors to stderr, and fails on warnings by default:
 
 ```json
 {
@@ -136,7 +138,16 @@ Add Slopwatch as a post-edit hook in `.claude/settings.json`:
 }
 ```
 
-The `--hook` flag analyzes only git-dirty files, outputs errors to stderr, and blocks the edit on failures.
+#### 4b: On-Demand (Copilot CLI)
+
+Ask `@dotnet-shihan` to run slopwatch. The agent executes `slopwatch analyze` via shell and interprets results:
+
+```
+@dotnet-shihan slopwatch を実行して
+@dotnet-shihan 近道してないかチェックして
+```
+
+The agent references this skill and the SLOP-xxx catalog during code reviews automatically.
 
 > **Values**: 成長の複利（自動ガードレールで品質を仕組み化）
 
@@ -172,7 +183,7 @@ Automated rules enforced by the Slopwatch CLI tool.
 | SW003 | Error | Empty catch blocks | `catch (Exception) { }` |
 | SW004 | Warning | Arbitrary delays | `await Task.Delay(1000);` in tests |
 | SW005 | Warning | Project file slop | `<NoWarn>CS1591</NoWarn>` |
-| SW006 | Warning | CPM bypass | Inline `Version="1.0.0"` |
+| SW006 | Error | Package version override | Inline `Version="1.0.0"` bypassing CPM |
 
 ---
 
@@ -318,6 +329,7 @@ slopwatch analyze --output json
 
 ## Resources
 
+- [Slopwatch GitHub](https://github.com/Aaronontheweb/dotnet-slopwatch) — Source code and documentation
 - [Slopwatch NuGet Package](https://www.nuget.org/packages/Slopwatch.Cmd)
 - [dotnet-local-tools](../dotnet-local-tools/SKILL.md) — Managing local .NET tools
 - [PHILOSOPHY.md](../../PHILOSOPHY.md) — Development constitution

--- a/dotnet/dotnet-slopwatch/references/SKILL.ja.md
+++ b/dotnet/dotnet-slopwatch/references/SKILL.ja.md
@@ -13,7 +13,7 @@ description: >
 metadata:
   author: RyoMurakami1983
   tags: [dotnet, quality, llm, anti-cheat, slopwatch]
-  invocable: true
+  invocable: false
 ---
 
 # Slopwatch: .NET向けLLMアンチチート
@@ -64,7 +64,7 @@ metadata:
   "isRoot": true,
   "tools": {
     "slopwatch.cmd": {
-      "version": "0.2.0",
+      "version": "0.3.4",  // check latest: dotnet tool search slopwatch
       "commands": ["slopwatch"],
       "rollForward": false
     }
@@ -114,9 +114,11 @@ Slopwatchが問題をフラグした場合、**無視しない**：
 
 > **Values**: 基礎と型（根本原因の修正が型）
 
-### Step 4 — Claude Code フックの設定
+### Step 4 — AIコーディングアシスタントとの統合
 
-`.claude/settings.json`にポストエディットフックとしてSlopwatchを追加する：
+#### 4a: 自動フック（Claude Code）
+
+`.claude/settings.json`にポストエディットフックとしてSlopwatchを追加する。`--hook` フラグはgit dirty filesのみを解析し、stderrにエラーを出力し、デフォルトで警告時に失敗する：
 
 ```json
 {
@@ -137,7 +139,18 @@ Slopwatchが問題をフラグした場合、**無視しない**：
 }
 ```
 
-**Why**: 自動ガードレールにより、LLMが編集するたびにスロップが即座にブロックされる。人間がレビューする前に品質が担保される。
+#### 4b: オンデマンド（Copilot CLI）
+
+`@dotnet-shihan` にslopwatch実行を依頼する。agentが `slopwatch analyze` をshell経由で実行し、結果を解釈する：
+
+```
+@dotnet-shihan slopwatch を実行して
+@dotnet-shihan 近道してないかチェックして
+```
+
+agentはコードレビュー時にこのスキルとSLOP-xxxカタログを自動的に参照する。
+
+**Why**: 自動ガードレール（Claude Code）またはオンデマンド検査（Copilot CLI）により、LLMのスロップが人間のレビュー前に検出される。
 
 > **Values**: 成長の複利（自動ガードレールで品質を仕組み化）
 
@@ -175,7 +188,7 @@ Slopwatch CLIツールが自動で適用するルール。
 | SW003 | Error | 空catchブロック | `catch (Exception) { }` |
 | SW004 | Warning | 恣意的な遅延 | テスト内の`await Task.Delay(1000);` |
 | SW005 | Warning | プロジェクトファイルスロップ | `<NoWarn>CS1591</NoWarn>` |
-| SW006 | Warning | CPMバイパス | インライン`Version="1.0.0"` |
+| SW006 | Error | パッケージバージョンオーバーライド | CPMバイパスのインライン`Version="1.0.0"` |
 
 ---
 
@@ -320,6 +333,7 @@ slopwatch analyze --update-baseline
 
 ## Resources
 
+- [Slopwatch GitHub](https://github.com/Aaronontheweb/dotnet-slopwatch) — ソースコードとドキュメント
 - [Slopwatch NuGet Package](https://www.nuget.org/packages/Slopwatch.Cmd)
 - [dotnet-local-tools](../dotnet-local-tools/SKILL.md) — .NETローカルツールの管理
 - [PHILOSOPHY.md](../../PHILOSOPHY.md) — 開発憲法


### PR DESCRIPTION
## 概要
dotnet-slopwatch を2層スロップ予防システムに再構成し、dotnet-shihan agentを深化。

### 変更内容
- **dotnet-slopwatch SKILL.md / SKILL.ja.md**: 2層構造に再構成
  - Layer 1 (SW-xxx): Slopwatch CLIツールによるコードレベル自動検出（既存維持）
  - Layer 2 (SLOP-xxx): アーキテクチャレベルのアンチパターンカタログ（新規）
  - SLOP-001: Layer Boundary Violation（層境界違反）追加
- **dotnet-shihan.agent.md**: 品質基準に「層の責務（SLOP検出）」セクション追加、レビューチェックリスト強化

### SLOP-001: Layer Boundary Violation
MillScanSplitter PR#20 のふりかえりから昇華。Presentation層でドメイン値を文字列パースで再構築するアンチパターン。
- 症状・処方・実例・チェックポイント・判断基準を網羅
- JA版は Why（深掘り）で根本原因を詳述

## 理由
MillScanSplitter PR#20 で発生した「鋼種名ハイフン問題」の教訓を、全プロジェクトで再利用可能な知識に昇華するため。
LLMの「データが足りないから手元で作る」Slop傾向への予防層として機能する。

## テスト
- validate_skill.py: 96.7% PASS (58/60, 閾値85%)
- EN/JA 構造パリティ確認済み
- 行数: EN 326行, JA 328行（500行制限内）

## 関連
MillScanSplitter PR#20 のふりかえりに基づく対策
