### PR TITLE
docs: dotnet-efcore-patterns に dotnet-ef 前提手順を追記

### DIFF
--- a/dotnet/dotnet-efcore-patterns/SKILL.md
+++ b/dotnet/dotnet-efcore-patterns/SKILL.md
@@ -96,7 +96,7 @@ await db.SaveChangesAsync();
 
 Use `dotnet ef` CLI commands exclusively. Never edit, delete, or rename migration files manually. Why: the snapshot file tracks cumulative state and manual changes corrupt it.
 
-> **Prerequisite**: If `dotnet ef` is not found, install the EF Core CLI tool first (`dotnet tool install --global dotnet-ef`) or use a local tool manifest and run `dotnet tool restore`.
+> **Prerequisite**: If `dotnet ef` is not found, either install the EF Core CLI tool globally (`dotnet tool install --global dotnet-ef`), or configure it as a local tool by creating a tool manifest if missing (`dotnet new tool-manifest`), installing `dotnet-ef` into it (`dotnet tool install dotnet-ef`), and then using `dotnet tool restore` in new clones/CI.
 
 ```bash
 # Create a new migration

--- a/dotnet/dotnet-efcore-patterns/references/SKILL.ja.md
+++ b/dotnet/dotnet-efcore-patterns/references/SKILL.ja.md
@@ -96,7 +96,7 @@ await db.SaveChangesAsync();
 
 `dotnet ef` CLI コマンドのみを使用する。マイグレーションファイルの手動編集・削除・名前変更は絶対にしない。スナップショットファイルは累積状態を追跡しており、手動変更は破損を引き起こすため。
 
-> **前提条件**: `dotnet ef` が見つからない場合は、EF Core CLI ツールを先にインストールする（`dotnet tool install --global dotnet-ef`）。ローカルツール運用の場合はマニフェスト作成後に `dotnet tool restore` を実行する。
+> **前提条件**: `dotnet ef` が見つからない場合は、まず EF Core CLI ツールをインストールする。グローバルツールとして使う場合は `dotnet tool install --global dotnet-ef` を実行する。リポジトリごとのローカルツールとして使う場合は、まだマニフェストがない場合にプロジェクトルートで `dotnet new tool-manifest` を実行し、その後 `dotnet tool install dotnet-ef` でマニフェストに登録する。以降はリポジトリのクローン後や CI では `dotnet tool restore` を実行すれば `dotnet ef` が利用できる。
 
 ```bash
 # 新しいマイグレーションを作成


### PR DESCRIPTION
## 概要
Issue #71 の把握フェーズで確認した高リスク項目のうち、`dotnet-efcore-patterns` にあった前提不足を最小修正しました。

## 変更内容
- `dotnet/dotnet-efcore-patterns/SKILL.md`
  - `dotnet ef` が見つからない場合の前提手順を追記
  - (`dotnet tool install --global dotnet-ef` / `dotnet tool restore`)
- `dotnet/dotnet-efcore-patterns/references/SKILL.ja.md`
  - 同内容を日本語版にも追記

## 検証
- `uv run python skills\skill-quality-validation\scripts\validate_skill.py dotnet\dotnet-efcore-patterns\SKILL.md`
- 結果: 96.7% PASS

## 関連
Refs #71
