### PR TITLE
docs: dotnet-skill-deploy にカテゴリ保守ルールを追加

### DIFF
--- a/skills/dotnet-skill-deploy/SKILL.md
+++ b/skills/dotnet-skill-deploy/SKILL.md
@@ -248,7 +248,7 @@ Deploy-DotnetSkills.ps1 -SourceRoot <dotnet_path> -Target <project> -Category wp
 
 ## Script Reference
 
-The deployment script is located at `scripts/Deploy-DotnetSkills.ps1`.
+The deployment script is located at repo-root-relative `skills/dotnet-skill-deploy/scripts/Deploy-DotnetSkills.ps1`.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|

--- a/skills/dotnet-skill-deploy/references/SKILL.ja.md
+++ b/skills/dotnet-skill-deploy/references/SKILL.ja.md
@@ -219,7 +219,7 @@ Get-ChildItem "<project_path>\.github\skills" -Directory | Select-Object Name
 
 ## スクリプトリファレンス
 
-デプロイスクリプトは `scripts/Deploy-DotnetSkills.ps1` に配置。
+デプロイスクリプトは repoルート相対パス `skills/dotnet-skill-deploy/scripts/Deploy-DotnetSkills.ps1` に配置。
 
 | パラメータ | 型 | 必須 | 説明 |
 |-----------|---|------|------|


### PR DESCRIPTION
## 概要
Issue #65 に対応し、`dotnet-skill-deploy` にカテゴリ定義メンテナンスルールを追加しました。

## 変更内容
- `skills/dotnet-skill-deploy/SKILL.md`
  - Best Practices に「カテゴリ定義を同期する」を追加
  - `Category Maintenance Rule` セクションを追加（CategoryMap更新、wpf-app確認、dotnet-shihan同期、`-List`確認）
- `skills/dotnet-skill-deploy/references/SKILL.ja.md`
  - 同等の「カテゴリ保守ルール」を追加

## 検証
- `uv run python skills\skill-quality-validation\scripts\validate_skill.py skills\dotnet-skill-deploy\SKILL.md`
- 結果: 95.0% PASS

## 関連
Closes #65
