### PR TITLE
docs(python-shihan): python-debug-tdd をスキル候補に追記 (Issue #96)

### DIFF
--- a/agents/python-shihan.agent.md
+++ b/agents/python-shihan.agent.md
@@ -78,6 +78,7 @@ Pythonエコシステムの進化を追い、新しいパターンを作る。
 ### 将来の成長領域（スキル化候補）
 - Python型注釈とmypyの実践
 - pytest パターン（fixture, parametrize, conftest設計）
+- `python-debug-tdd` — TDD型バグ修正ワークフロー（再現テスト→根本原因特定→最小修正→副作用確認）([Issue #96](https://github.com/RyoMurakami1983/skills_repository/issues/96))
 - uv / ruff / pyproject.toml エコシステム
 - FastAPI / Pydantic パターン
 - データ処理（pandas, polars）


### PR DESCRIPTION
## 変更内容

\gents/python-shihan.agent.md\ の「将来の成長領域（スキル化候補）」に \python-debug-tdd\ スキルを追記。

## 背景

slit_optimizer プロジェクトでのバグ修正作業（2026-03-04）で実証された
TDD型バグ修正ワークフローをpython-shihan管轄スキルとして形式知化する予定。
Issue #96 で追跡中。

## 変更箇所

- \gents/python-shihan.agent.md\: 将来候補に1行追加