### PR TITLE
feat: furikaeri-practice に Notion 保存ステップを追加

### DIFF
--- a/skills/furikaeri-practice/SKILL.md
+++ b/skills/furikaeri-practice/SKILL.md
@@ -244,8 +244,9 @@ Convert prioritized actions from Steps 3–4 into trackable execution items.
 > **Applies to**: sessions where `metadata.author == "RyoMurakami1983"` (i.e., this skills_repository).
 > Skip this step in other contexts.
 
-Save the furikaeri record to the Notion database:
-**`copilot-cliのふりかえりログ`** (`collection://319b5a4c-d694-80a5-a35e-000bf54edcce`)
+Save the furikaeri record to your designated private Notion database for furikaeri logs.
+
+> **How to get the `data_source_id`**: Run `notion-notion-fetch` on your furikaeri log database URL to retrieve the `collection://...` ID from the `<data-source>` tag. Store this ID in your local agent configuration — do **not** commit the actual UUID to the repository.
 
 Map KPT/YWT outputs to database fields:
 
@@ -260,9 +261,9 @@ Map KPT/YWT outputs to database fields:
 | `次回アクション` | SMART goals + Issue numbers (from Steps 3–4 + 6a) |
 | `関連タグ` | JSON array — choose from: `["開発", "デバッグ", "設計", "テスト", "レビュー", "リファクタリング", "ドキュメント", "会議", "学習"]` |
 
-Use `notion-notion-create-pages` with `data_source_id: "319b5a4c-d694-80a5-a35e-000bf54edcce"`.
+Use `notion-notion-create-pages` with `data_source_id: "<NOTION_DATA_SOURCE_ID>"` (your local value).
 
-Use when finishing any furikaeri in the RyoMurakami1983 context. Enables long-term trend tracking.
+Use when finishing any furikaeri in this workspace or team context. Enables long-term trend tracking.
 
 > **Values**: 継続は力 / 成長の複利 / 基礎と型
 
@@ -385,7 +386,7 @@ A: Steps 1–3, 5, and 6 are recommended for most sessions. Step 4 (5 Whys + SMA
 A: Great sessions still have Keep items and Try items. "What could be even better?" always yields insights.
 
 **Q: Should I store furikaeri notes somewhere?**
-A: Yes. For `RyoMurakami1983` sessions, save to the Notion database `copilot-cliのふりかえりログ` via Step 6b. For other contexts, create a GitHub Issue with the `furikaeri` label, or keep a `FURIKAERI.md` in your project.
+A: Yes. For `RyoMurakami1983` sessions, save to your designated private Notion database for furikaeri logs via Step 6b. For other contexts, create a GitHub Issue with the `furikaeri` label, or keep a `FURIKAERI.md` in your project.
 
 ---
 

--- a/skills/furikaeri-practice/references/SKILL.ja.md
+++ b/skills/furikaeri-practice/references/SKILL.ja.md
@@ -243,8 +243,9 @@ Problem項目の根本原因が不明な場合、またはTry項目に具体的�
 > **適用条件**: `metadata.author == "RyoMurakami1983"` のセッション（このskills_repository）のみ。
 > その他のコンテキストではこのステップをスキップする。
 
-ふりかえり内容を Notion データベース  
-**`copilot-cliのふりかえりログ`** (`collection://319b5a4c-d694-80a5-a35e-000bf54edcce`) に保存する。
+ふりかえり内容を、自分専用のプライベート Notion ふりかえりログ DB に保存する。
+
+> **`data_source_id` の取得方法**: ふりかえりログ DB の URL に対して `notion-notion-fetch` を実行し、`<data-source>` タグの `collection://...` ID を取得する。この値はローカルのエージェント設定に保存し、**リポジトリにはコミットしない**こと。
 
 KPT/YWT のアウトプットをフィールドにマッピングする:
 
@@ -259,7 +260,7 @@ KPT/YWT のアウトプットをフィールドにマッピングする:
 | `次回アクション` | SMART 目標 + Issue 番号（Steps 3–4 + 6a から） |
 | `関連タグ` | JSON 配列 — 選択肢: `["開発", "デバッグ", "設計", "テスト", "レビュー", "リファクタリング", "ドキュメント", "会議", "学習"]` |
 
-`notion-notion-create-pages` を `data_source_id: "319b5a4c-d694-80a5-a35e-000bf54edcce"` で呼び出す。
+`notion-notion-create-pages` を `data_source_id: "<NOTION_DATA_SOURCE_ID>"` で呼び出す（ローカル設定から取得した値を使用）。
 
 > **なぜ？** — GitHub Issue は「次にやること」の追跡に強く、Notion は「時系列のふりかえりログ」として長期トレンドの把握に強い。両方を使うことで、実行管理と成長記録を分離できる。
 
@@ -384,7 +385,7 @@ A: 基本は Step 1〜3・Step 5・Step 6 を実施。Step 4（5つのなぜ + S
 A: 良いセッションにもKeep項目やTry項目がある。「もっと良くするには？」は必ず何かを生む。
 
 **Q: ふりかえりノートはどこに保存する？**
-A: `RyoMurakami1983` のセッションでは Step 6b で Notion データベース `copilot-cliのふりかえりログ` に保存する。その他のコンテキストでは GitHub Issue に `furikaeri` ラベルをつけるか、プロジェクトに `FURIKAERI.md` を置く。
+A: `RyoMurakami1983` のセッションでは Step 6b で自分専用のプライベート Notion ふりかえりログ DB に保存する。その他のコンテキストでは GitHub Issue に `furikaeri` ラベルをつけるか、プロジェクトに `FURIKAERI.md` を置く。
 
 ---
 


### PR DESCRIPTION
## 概要
`furikaeri-practice` スキルに Notion 保存ステップ（Step 6b）を追加。

## 変更内容
- Step 6 を `6a: GitHub Issue 登録` と `6b: Notion 保存` に分割
- 6b は `RyoMurakami1983` コンテキストのみ適用（他リポジトリでは Skip）
- KPT/YWT → Notion フィールドのマッピング表を記載
- JA版（SKILL.ja.md）に「なぜ？」解説を追加
- FAQ の「ふりかえりノートの保存先」を更新

## 理由
今回のふりかえりセッションで Notion への保管ニーズが判明。
GitHub Issue は「実行追跡」、Notion は「成長記録」として役割を分離する。

## テスト
`validate_skill.py` にて 91.7% PASS (55/60) 確認済み。

## 関連
Refs #102
