### PR TITLE
feat(furikaeri-practice): Step 6 強化 — Try→Issue 橋渡しと skill 改善ルーティング（#88 #92）

### DIFF
--- a/skills/furikaeri-practice/SKILL.md
+++ b/skills/furikaeri-practice/SKILL.md
@@ -241,6 +241,10 @@ Convert prioritized actions from Steps 3–4 into trackable execution items.
 | Standardize test timeout configuration | #129 |
 ```
 
+> **Action type routing**
+> - **Coding/process improvements** → Create a GitHub Issue (this step)
+> - **Skill/pattern/workflow improvements** → Invoke `skills-revise-skill` to update the relevant skill
+
 #### 6b: Save to Notion (RyoMurakami1983 only)
 
 > **Applies to**: sessions where `metadata.author == "RyoMurakami1983"` (i.e., this skills_repository).

--- a/skills/furikaeri-practice/references/SKILL.ja.md
+++ b/skills/furikaeri-practice/references/SKILL.ja.md
@@ -240,6 +240,10 @@ Problem項目の根本原因が不明な場合、またはTry項目に具体的�
 | テストセットアップへタイムアウト設定を追加（今週中） | Draft: "Add timeout config to integration tests" |
 ```
 
+> **アクション種別による分岐**
+> - **コーディング・プロセスの改善** → GitHub Issue を作成（本ステップ）
+> - **skill・型・ワークフローの改善** → `skills-revise-skill` を起動して該当スキルを更新
+
 #### 6b: Notion へ保存（RyoMurakami1983 のみ）
 
 > **適用条件**: `metadata.author == "RyoMurakami1983"` のセッション（このskills_repository）のみ。


### PR DESCRIPTION
## 概要

Step 3 と Step 6a を強化し、ふりかえりセッションの「アクション登録漏れ」を防ぐ。

## 変更内容

### #88 — Step 3 末尾に Step 6a への橋渡し note を追加
- Step 3（優先アイテム確定）直後に「Step 6 を完了せずに終わらないこと」を明示
- エージェントが Step 6 をスキップする抜け道を塞ぐ

### #92 — Step 6a 末尾にアクション種別分岐ルーティングを追加
- コーディング/プロセス改善 → GitHub Issue（従来通り）
- skill/型/ワークフロー改善 → `skills-revise-skill` を起動

## 理由

Try アイテムが会話中で識別されても Step 6a 未到達のまま終わるケースが複数回発生。
また skill 改善の知見が GitHub Issue で止まり、スキル自体が更新されない問題があった。
最小変更で2つの抜け道を塞ぐ。

## テスト

- EN/JA 両方変更済み、構造パリティ維持
- 行数: EN 404行 / JA 403行（500行以内）

## 関連

Closes #88
Closes #92