### PR TITLE
fix(github-pr-workflow): Step 2 冒頭に gh auth status チェックを追加（#90）

### DIFF
--- a/skills/github-pr-workflow/SKILL.md
+++ b/skills/github-pr-workflow/SKILL.md
@@ -103,6 +103,8 @@ Use when any PR-related request is received.
 Branch from the latest main. Use descriptive prefixes (`feature/`, `fix/`, `docs/`) with the issue number.
 
 ```bash
+# Verify authentication before branching (catches push failures early)
+gh auth status
 git switch main
 git pull --ff-only
 git switch -c feature/issue-123

--- a/skills/github-pr-workflow/references/SKILL.ja.md
+++ b/skills/github-pr-workflow/references/SKILL.ja.md
@@ -103,6 +103,8 @@ gh pr list --head $Branch --state open
 最新のmainからブランチを作成します。追跡性のためにIssue番号付きの説明的プレフィックス（`feature/`、`fix/`、`docs/`）を使用します。
 
 ```bash
+# ブランチ作成前に認証確認（push失敗を防ぐ）
+gh auth status
 git switch main
 git pull --ff-only
 git switch -c feature/issue-123


### PR DESCRIPTION
## 概要

Step 2（フィーチャーブランチ作成）の冒頭に `gh auth status` を追加し、
push 失敗を事前に防ぐ。

## 理由

ブランチ作成・コミット完了後の push 段階で初めて認証不足が判明するケースが発生。
typescript-shihan セッション（2026-03-03）で `gh auth login` が3回失敗し約6分ロス。
Preflight には auth チェックがあるが、Step 2 到達時点で未確認のまま進むことがあった。

## 変更内容

- EN/JA 両方の Step 2 コードブロック冒頭に `gh auth status` を追加
- コメントで「push失敗を防ぐため」の意図を明示

## テスト

- 行数: EN/JA とも 274行（500行以内）
- 既存フロー（ブランチ作成・PR作成）への影響なし

## 関連

Closes #90