### PR TITLE
docs(typescript-tauri-setup): Tauriビルド知見を4項目追記

### DIFF
--- a/typescript/typescript-tauri-setup/SKILL.md
+++ b/typescript/typescript-tauri-setup/SKILL.md
@@ -348,14 +348,14 @@ Fix: Use NSIS target or install WiX Toolset separately. The app binary works reg
 
 5. **`outDir` relative path when using a custom Vite `root`**
 Fix: When `root` is set (e.g., `src/editor`), `outDir: 'dist'` outputs to `src/editor/dist`, not the project root. This causes a mismatch with `frontendDist: "../dist"` in `tauri.conf.json`.
-```typescript
-// ❌ Outputs to src/editor/dist when root is 'src/editor'
-outDir: 'dist',
+   ```typescript
+   // ❌ Outputs to src/editor/dist when root is 'src/editor'
+   outDir: 'dist',
 
-// ✅ Always outputs to project root/dist regardless of root setting
-import { resolve } from 'path';
-outDir: resolve(__dirname, 'dist'),
-```
+   // ✅ Always outputs to project root/dist regardless of root setting
+   import { resolve } from 'path';
+   outDir: resolve(__dirname, 'dist'),
+   ```
 
 ---
 

--- a/typescript/typescript-tauri-setup/references/SKILL.ja.md
+++ b/typescript/typescript-tauri-setup/references/SKILL.ja.md
@@ -343,14 +343,14 @@ error: failed to download WiX
 
 5. **カスタム Vite `root` 設定時の `outDir` 相対パス**
 修正: `root: 'src/editor'` などを設定すると `outDir: 'dist'` は `src/editor/dist` に出力され、`tauri.conf.json` の `frontendDist: "../dist"` と一致しなくなる。
-```typescript
-// ❌ root が 'src/editor' のとき src/editor/dist に出力
-outDir: 'dist',
+   ```typescript
+   // ❌ root が 'src/editor' のとき src/editor/dist に出力
+   outDir: 'dist',
 
-// ✅ root 設定に関わらず常にプロジェクトルート/dist に出力
-import { resolve } from 'path';
-outDir: resolve(__dirname, 'dist'),
-```
+   // ✅ root 設定に関わらず常にプロジェクトルート/dist に出力
+   import { resolve } from 'path';
+   outDir: resolve(__dirname, 'dist'),
+   ```
 
 ---
 


### PR DESCRIPTION
## 概要
`typescript-tauri-setup` スキルにTauriビルド知見を4項目追記。

## 理由
typescript-shihanセッション中に実際に遭遇したトラブル（tauri:build 空白ウィンドウ、outDir パスズレ、ARM64クロスコンパイル、cargo check待機時間）をスキルに反映し、次のエンジニアが同じ問題で時間を失わないよう形式知化。

## 変更内容
- **Step 7 Issue 6追加**: `tauri:dev` vs `tauri:build` の動作差異（devUrl/frontendDist）
- **Common Pitfall 5追加**: カスタム Vite `root` 設定時の `outDir` 相対パス問題＋コード例
- **Decision Table行追加**: ARM64 Windows での x64 クロスコンパイル手順
- **FAQ更新**: `cargo check` 初回実行時 3〜5分待機の説明を追記

EN/JA両バージョン更新済み。ライン数: EN 450行・JA 445行（500行上限以内）。

## テスト
ローカルでラインカウント・内容確認済み。

## 関連
Closes #91
