### PR TITLE
feat(notion): Notion基盤スキルを新設しfurikaeri連携を標準化

### DIFF
--- a/skills/furikaeri-practice/SKILL.md
+++ b/skills/furikaeri-practice/SKILL.md
@@ -250,9 +250,11 @@ Convert prioritized actions from Steps 3–4 into trackable execution items.
 > **Applies to**: sessions where `metadata.author == "RyoMurakami1983"` (i.e., this skills_repository).
 > Skip this step in other contexts.
 
-Save the furikaeri record to your designated private Notion database for furikaeri logs.
+Save the furikaeri record using **`notion-safe-operations`**.
 
-> **How to get the `data_source_id`**: Run `notion-notion-fetch` on your furikaeri log database URL to retrieve the `collection://...` ID from the `<data-source>` tag. Store this ID in your local agent configuration — do **not** commit the actual UUID to the repository.
+> **Why this routing?** Notion tool availability may differ by session/agent/model. The base skill enforces preflight checks, secure DS ID handling, and deterministic fallback payloads.
+
+> **DS ID policy**: Use local environment variables (for example, `NOTION_FURIKAERI_DS_ID`) or local agent config. Do **not** commit real UUIDs.
 
 Map KPT/YWT outputs to database fields:
 
@@ -267,7 +269,7 @@ Map KPT/YWT outputs to database fields:
 | `次回アクション` | SMART goals + Issue numbers (from Steps 3–4 + 6a) |
 | `関連タグ` | JSON array — choose from: `["開発", "デバッグ", "設計", "テスト", "レビュー", "リファクタリング", "ドキュメント", "会議", "学習"]` |
 
-Use `notion-notion-create-pages` with `data_source_id: "<NOTION_DATA_SOURCE_ID>"` (your local value).
+Invoke `notion-safe-operations` and pass this mapped content into the create-page payload.
 
 Use when finishing any furikaeri in this workspace or team context. Enables long-term trend tracking.
 

--- a/skills/furikaeri-practice/references/SKILL.ja.md
+++ b/skills/furikaeri-practice/references/SKILL.ja.md
@@ -249,9 +249,11 @@ Problem項目の根本原因が不明な場合、またはTry項目に具体的�
 > **適用条件**: `metadata.author == "RyoMurakami1983"` のセッション（このskills_repository）のみ。
 > その他のコンテキストではこのステップをスキップする。
 
-ふりかえり内容を、自分専用のプライベート Notion ふりかえりログ DB に保存する。
+ふりかえり内容は **`notion-safe-operations`** を使って保存する。
 
-> **`data_source_id` の取得方法**: ふりかえりログ DB の URL に対して `notion-notion-fetch` を実行し、`<data-source>` タグの `collection://...` ID を取得する。この値はローカルのエージェント設定に保存し、**リポジトリにはコミットしない**こと。
+> **なぜこの分岐？** Notionツールの可用性はセッション/エージェント/モデルで変動する。基盤スキルに集約することで、Preflight確認・DS ID安全管理・失敗時フォールバックを一貫運用できる。
+
+> **DS ID 運用方針**: `NOTION_FURIKAERI_DS_ID` などのローカル環境変数、またはローカル設定を使う。実UUIDをリポジトリへコミットしない。
 
 KPT/YWT のアウトプットをフィールドにマッピングする:
 
@@ -266,7 +268,7 @@ KPT/YWT のアウトプットをフィールドにマッピングする:
 | `次回アクション` | SMART 目標 + Issue 番号（Steps 3–4 + 6a から） |
 | `関連タグ` | JSON 配列 — 選択肢: `["開発", "デバッグ", "設計", "テスト", "レビュー", "リファクタリング", "ドキュメント", "会議", "学習"]` |
 
-`notion-notion-create-pages` を `data_source_id: "<NOTION_DATA_SOURCE_ID>"` で呼び出す（ローカル設定から取得した値を使用）。
+`notion-safe-operations` を呼び出し、上記マッピング済みコンテンツを create-page payload に渡す。
 
 > **なぜ？** — GitHub Issue は「次にやること」の追跡に強く、Notion は「時系列のふりかえりログ」として長期トレンドの把握に強い。両方を使うことで、実行管理と成長記録を分離できる。
 

--- a/skills/notion-safe-operations/SKILL.md
+++ b/skills/notion-safe-operations/SKILL.md
@@ -1,0 +1,222 @@
+---
+name: notion-safe-operations
+description: Use when you need reliable and secure Notion MCP operations with preflight checks, DS ID handling, and fallback payloads.
+metadata:
+  author: RyoMurakami1983
+  tags: [notion, mcp, workflow, security, reliability]
+  invocable: false
+  last_reviewed: "2026-03-05"
+---
+
+# Notion Safe Operations
+
+Use one reusable workflow for Notion operations instead of duplicating ad-hoc steps per skill.
+
+## When to Use This Skill
+
+Use this skill when:
+- Saving retrospective records to Notion from another skill
+- Updating page properties in a Notion data source
+- Validating tool availability after agent/model changes
+- Resolving a Data Source (DS) ID from local secure config
+- Handling create/update failures without blocking user progress
+- Standardizing Notion operation behavior across skills
+
+## Related Skills
+
+- **`furikaeri-practice`** - Stores retrospective logs to Notion
+- **`knowledge-capture`** - Applies anonymization before public outputs
+- **`skills-revise-skill`** - Applies this base pattern to existing skills
+
+---
+
+## Dependencies
+
+- Notion MCP tools (`notion-notion-fetch`, `notion-notion-create-pages`)
+- Local environment variable for DS ID (example: `NOTION_FURIKAERI_DS_ID`)
+- Target Notion database access permissions
+
+---
+
+## Core Principles
+
+1. **Run Preflight First** - Execute a real call before writing (基礎と型)
+2. **Store IDs Locally** - Keep DS IDs outside repository files (ニュートラル)
+3. **Fail with Context** - Return actionable fallback payloads (継続は力)
+4. **Reuse One Workflow** - Eliminate duplicated Notion procedures (温故知新)
+5. **Explain Rationale** - Always include why each guard exists (成長の複利)
+
+---
+
+## Workflow: Safe Notion Execution
+
+### Step 1: Run Tool Preflight
+
+Run a real fetch call before any write operation.
+
+```text
+# ✅ CORRECT - verify callable tool path
+notion-notion-fetch(id="collection://<your-data-source-id>")
+
+# ❌ WRONG - trust static listing only
+/mcp show
+```
+
+| Signal | Decision |
+|---|---|
+| Fetch succeeds | Continue to Step 2 |
+| Tool missing / fetch fails | Stop writes and use Step 5 fallback |
+
+Why: `/mcp show` can list integrations while current runtime still cannot invoke the tool.
+
+> **Values**: 基礎と型 / 継続は力
+
+### Step 2: Resolve DS ID Securely
+
+Load DS ID from local environment variables first.
+
+```bash
+# preferred local config
+export NOTION_FURIKAERI_DS_ID="collection://..."
+```
+
+If missing, fetch the database URL and read `collection://...` from the `<data-source>` tag.
+
+```text
+notion-notion-fetch(id="https://www.notion.so/...database-url...")
+```
+
+Why: local configuration is reproducible and avoids leaking workspace identifiers.
+
+> **Values**: ニュートラル / 基礎と型
+
+### Step 3: Validate Schema Before Write
+
+Fetch the target data source and verify property names before creating pages.
+
+```text
+notion-notion-fetch(id="collection://...")
+# Check required properties exist with exact names:
+# タイトル, ステータス, 実施内容, 学び・気づき, 課題・問題点, 次回アクション
+```
+
+Why: property name mismatch is the most common source of create/update failures.
+
+> **Values**: 成長の複利 / 基礎と型
+
+### Step 4: Execute Create/Update
+
+Use explicit property keys and expanded date fields.
+
+```json
+{
+  "parent": { "data_source_id": "<resolved-id>" },
+  "pages": [
+    {
+      "properties": {
+        "タイトル": "Session title",
+        "ステータス": "完了",
+        "実施内容": "...",
+        "学び・気づき": "...",
+        "課題・問題点": "...",
+        "次回アクション": "...",
+        "関連タグ": "[\"開発\", \"レビュー\"]",
+        "date:セッション日時:start": "2026-03-05",
+        "date:セッション日時:is_datetime": 0
+      }
+    }
+  ]
+}
+```
+
+Why: explicit keys reduce ambiguity and improve repeatability across sessions.
+
+> **Values**: 基礎と型 / 温故知新
+
+### Step 5: Return Deterministic Fallback
+
+If write execution fails, return a copy-paste payload and retry guidance.
+
+```markdown
+## Notion write failed
+- Error: <exact error>
+- Retry:
+  1. Reset agent/model context
+  2. Re-run Step 1 preflight
+  3. Re-submit the same payload
+
+Payload:
+{ ...ready-to-paste JSON... }
+```
+
+Why: a structured fallback preserves momentum even when tools are unstable.
+
+> **Values**: 継続は力 / 成長の複利
+
+---
+
+## Common Pitfalls
+
+1. **Using `/mcp show` as the only health check**
+   Fix: Always run `notion-notion-fetch` preflight before writes.
+
+2. **Hardcoding DS ID in committed markdown**
+   Fix: Store DS ID in local environment variables.
+
+3. **Guessing property names**
+   Fix: Fetch schema and copy exact field names.
+
+---
+
+## Best Practices
+
+- Run preflight in every write flow
+- Reuse this skill from other skills instead of duplicating procedures
+- Keep fallback payloads short and executable
+- Keep sensitive identifiers in local-only configuration
+
+## Anti-Patterns
+
+- Proceeding after preflight failure
+- Returning generic "failed" messages without retry steps
+- Mixing inline Notion logic into unrelated workflow skills
+
+---
+
+## Quick Reference
+
+### Decision Table
+
+| Situation | Action |
+|---|---|
+| Need to write Notion data | Run Step 1 preflight first |
+| DS ID unknown | Run Step 2 resolution flow |
+| Property error occurs | Re-run Step 3 schema check |
+| Tool call fails in runtime | Use Step 5 fallback payload |
+
+### Minimal Checklist
+
+- [ ] Preflight fetch succeeded
+- [ ] DS ID resolved from local config
+- [ ] Schema verified
+- [ ] Payload uses exact property names
+- [ ] Fallback payload prepared
+
+---
+
+## FAQ
+
+**Q: Why not save DS IDs in repository docs?**
+A: DS IDs are workspace-specific identifiers; local-only storage is safer and cleaner.
+
+**Q: Why run preflight every time?**
+A: Model/agent context changes can affect callable tool availability.
+
+**Q: What is MCP?**
+A: MCP means Model Context Protocol, the tool bridge used to call integrations like Notion.
+
+---
+
+## Resources
+
+- https://developers.notion.com/reference/intro

--- a/skills/notion-safe-operations/references/SKILL.ja.md
+++ b/skills/notion-safe-operations/references/SKILL.ja.md
@@ -1,0 +1,220 @@
+---
+name: notion-safe-operations
+description: Notion MCP 操作を安全・再現可能に実行するための基盤スキル。Preflight、DS ID運用、失敗時フォールバックを標準化する。
+metadata:
+  author: RyoMurakami1983
+  tags: [notion, mcp, workflow, security, reliability]
+  invocable: false
+  last_reviewed: "2026-03-05"
+---
+
+# Notion Safe Operations
+
+Notion操作をスキル横断で共通化し、セッション差分による失敗を減らすための標準手順です。
+
+## このスキルを使うとき
+
+以下の状況で使います：
+- ふりかえり結果を Notion に保存するとき
+- Notion ページのプロパティ更新を実行するとき
+- agent/model 切替後にツール可用性を確認するとき
+- Data Source（DS）ID を安全に解決するとき
+- create/update 失敗時に作業停止を避けたいとき
+- Notion運用をスキル間で統一したいとき
+
+## 関連スキル
+
+- **`furikaeri-practice`** - ふりかえりログの保存
+- **`knowledge-capture`** - 公開前の匿名化
+- **`skills-revise-skill`** - 既存スキルへの適用
+
+---
+
+## 依存関係
+
+- Notion MCP ツール（`notion-notion-fetch`, `notion-notion-create-pages`）
+- DS ID 用のローカル環境変数（例: `NOTION_FURIKAERI_DS_ID`）
+- 対象 Notion DB へのアクセス権
+
+---
+
+## コア原則
+
+1. **Run Preflight First** - 書き込み前に実呼び出しで確認する（基礎と型）
+2. **Store IDs Locally** - DS ID は repo外で管理する（ニュートラル）
+3. **Fail with Context** - 失敗時は再実行可能な情報を返す（継続は力）
+4. **Reuse One Workflow** - Notion手順を重複記述しない（温故知新）
+5. **Explain Rationale** - 手順と理由をセットで残す（成長の複利）
+
+---
+
+## ワークフロー: Notionを安全に実行する
+
+### Step 1: ツール Preflight 実行
+
+書き込み前に、実際の fetch を1回実行する。
+
+```text
+# ✅ CORRECT - 実呼び出し確認
+notion-notion-fetch(id="collection://<your-data-source-id>")
+
+# ❌ WRONG - 一覧表示だけで可用性判定
+/mcp show
+```
+
+| シグナル | 判断 |
+|---|---|
+| fetch成功 | Step 2へ進む |
+| ツール未検出/失敗 | Step 5フォールバックへ |
+
+**なぜ？** `/mcp show` で見えても、実行コンテキストで呼べない場合があるため。
+
+> **Values**: 基礎と型 / 継続は力
+
+### Step 2: DS ID を安全に解決
+
+まずローカル環境変数を使う。
+
+```bash
+export NOTION_FURIKAERI_DS_ID="collection://..."
+```
+
+未設定なら DB URL を fetch し、`<data-source>` の `collection://...` を取得する。
+
+```text
+notion-notion-fetch(id="https://www.notion.so/...database-url...")
+```
+
+**なぜ？** ローカル設定は再現性が高く、識別子漏洩も防げるため。
+
+> **Values**: ニュートラル / 基礎と型
+
+### Step 3: スキーマ確認
+
+対象 data source を fetch し、必須プロパティ名を完全一致で確認する。
+
+```text
+notion-notion-fetch(id="collection://...")
+# 必須: タイトル, ステータス, 実施内容, 学び・気づき, 課題・問題点, 次回アクション
+```
+
+**なぜ？** create/update 失敗の多くはプロパティ名の不一致が原因。
+
+> **Values**: 成長の複利 / 基礎と型
+
+### Step 4: Create/Update 実行
+
+明示的なプロパティ名と日付expanded keysを使う。
+
+```json
+{
+  "parent": { "data_source_id": "<resolved-id>" },
+  "pages": [
+    {
+      "properties": {
+        "タイトル": "Session title",
+        "ステータス": "完了",
+        "実施内容": "...",
+        "学び・気づき": "...",
+        "課題・問題点": "...",
+        "次回アクション": "...",
+        "関連タグ": "[\"開発\", \"レビュー\"]",
+        "date:セッション日時:start": "2026-03-05",
+        "date:セッション日時:is_datetime": 0
+      }
+    }
+  ]
+}
+```
+
+**なぜ？** 曖昧さを減らし、セッション間で同じ結果を再現しやすくするため。
+
+> **Values**: 基礎と型 / 温故知新
+
+### Step 5: 失敗時フォールバック
+
+失敗時は必ず、貼り付け可能 payload と再試行手順を返す。
+
+```markdown
+## Notion write failed
+- Error: <exact error>
+- Retry:
+  1. agent/model を再初期化
+  2. Step 1 preflight を再実行
+  3. 同じ payload を再送
+
+Payload:
+{ ...ready-to-paste JSON... }
+```
+
+**なぜ？** ツール不安定時でも、ユーザーの作業を止めないため。
+
+> **Values**: 継続は力 / 成長の複利
+
+---
+
+## Common Pitfalls
+
+1. **`/mcp show` だけで健全性判定する**
+   修正: 書き込み前に `notion-notion-fetch` を必ず実行。
+
+2. **DS ID をコミット済みファイルに直書きする**
+   修正: ローカル環境変数で管理する。
+
+3. **プロパティ名を推測して書く**
+   修正: スキーマを fetch して正確な名前を使用。
+
+---
+
+## ベストプラクティス
+
+- すべての write フローで preflight を実行
+- Notion手順は基盤スキルに集約
+- 失敗時payloadは即貼り付け可能形式にする
+- 機密識別子はローカル設定に限定する
+
+## アンチパターン
+
+- preflight 失敗後にそのまま書き込み継続
+- 再試行情報なしで「失敗しました」だけ返す
+- 各スキルにNotion手順を重複記載する
+
+---
+
+## Quick Reference
+
+### Decision Table
+
+| 状況 | アクション |
+|---|---|
+| Notionへ書き込みたい | Step 1 preflight を先に実行 |
+| DS ID が不明 | Step 2 解決フローを実行 |
+| Property error が出た | Step 3 スキーマ確認を再実行 |
+| 実行時にツール失敗 | Step 5 フォールバックを返す |
+
+### 最小チェックリスト
+
+- [ ] preflight fetch 成功
+- [ ] DS ID をローカル設定から解決
+- [ ] スキーマ確認済み
+- [ ] payload が正確なプロパティ名を使用
+- [ ] フォールバックpayloadを準備
+
+---
+
+## FAQ
+
+**Q: なぜ DS ID をリポジトリに書かない？**
+A: ワークスペース固有識別子の漏洩を防ぎ、環境依存を減らすため。
+
+**Q: なぜ毎回 preflight が必要？**
+A: セッション/agent/model でツール可用性が変動するため。
+
+**Q: MCP とは？**
+A: Model Context Protocol の略で、Notion など外部ツール呼び出しの橋渡し。
+
+---
+
+## Resources
+
+- https://developers.notion.com/reference/intro


### PR DESCRIPTION
## 概要
Notion利用をスキル横断で再利用できる基盤スキル `notion-safe-operations` を新設し、`furikaeri-practice` Step 6b をこの基盤スキル呼び出しに統一しました。

## 理由
`/mcp show` の表示だけでは実行可否を保証できず、セッション/agent/model 差分で Notion ツール呼び出しが失敗するケースがあったため。運用依存（気をつける）ではなく、Preflight と fallback を持つ再利用可能な型として仕組み化します。

## 変更内容
- `skills/notion-safe-operations/SKILL.md` 新規作成（EN）
- `skills/notion-safe-operations/references/SKILL.ja.md` 新規作成（JA）
- `furikaeri-practice` Step 6b を基盤スキル呼び出し型に更新（EN/JA）
- DS ID運用方針をローカル環境変数中心に明文化（実UUID非コミット）

## 検証
- `python3 skills/skill-quality-validation/scripts/validate_skill.py skills/notion-safe-operations/SKILL.md` → 95.0% PASS
- `python3 skills/skill-quality-validation/scripts/validate_skill.py skills/furikaeri-practice/SKILL.md` → 91.7% PASS

## 関連
Closes #108
