### PR TITLE
docs(github-pr): 安全な body-file 運用を標準化

### DIFF
--- a/skills/github-pr-review-response/SKILL.md
+++ b/skills/github-pr-review-response/SKILL.md
@@ -229,8 +229,15 @@ Push all fix commits, then reply to each review comment explaining what was done
 git push origin HEAD
 
 # Add a general review comment summarizing changes via body-file.
-# Why: review replies often include backticks, bullets, and commit hashes.
-REVIEW_BODY="${TMPDIR:-/tmp}/review_response.md"
+# Why: mktemp avoids collisions, and trap cleans up even on failures.
+REVIEW_BODY="$(mktemp "${TMPDIR:-/tmp}/review_response.XXXXXX")" || {
+  echo "Failed to create temporary file for review response" >&2
+  exit 1
+}
+cleanup_review_body() {
+  [ -n "$REVIEW_BODY" ] && rm -f "$REVIEW_BODY"
+}
+trap cleanup_review_body EXIT
 cat > "$REVIEW_BODY" <<'EOF'
 All review comments addressed. See individual commits for details.
 
@@ -239,7 +246,6 @@ All review comments addressed. See individual commits for details.
 EOF
 
 gh pr review --comment --body-file "$REVIEW_BODY"
-rm -f "$REVIEW_BODY"
 
 # For threaded replies to specific review comments, use GitHub web UI
 # or the API: gh api repos/OWNER/REPO/pulls/comments/COMMENT_ID/replies -f body="Fixed in abc1234"
@@ -273,7 +279,14 @@ After all comments are addressed and pushed, request a re-review from the origin
 gh pr edit --add-reviewer reviewer-username
 
 # Optionally leave a summary comment via body-file
-REREVIEW_BODY="${TMPDIR:-/tmp}/rereview_summary.md"
+REREVIEW_BODY="$(mktemp "${TMPDIR:-/tmp}/rereview_summary.XXXXXX")" || {
+  echo "Failed to create temporary file for re-review summary" >&2
+  exit 1
+}
+cleanup_rereview_body() {
+  [ -n "$REREVIEW_BODY" ] && rm -f "$REREVIEW_BODY"
+}
+trap cleanup_rereview_body EXIT
 cat > "$REREVIEW_BODY" <<'EOF'
 All review comments addressed:
 - Fixed SQL injection (commit abc1234)
@@ -284,7 +297,6 @@ Ready for re-review. Thank you for the feedback!
 EOF
 
 gh pr comment --body-file "$REREVIEW_BODY"
-rm -f "$REREVIEW_BODY"
 ```
 
 ```powershell

--- a/skills/github-pr-review-response/references/SKILL.ja.md
+++ b/skills/github-pr-review-response/references/SKILL.ja.md
@@ -229,8 +229,15 @@ Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
 git push origin HEAD
 
 # body-fileで全体コメントを追加
-# なぜ: レビュー返信はバッククォート、箇条書き、コミットハッシュを含みやすい
-REVIEW_BODY="${TMPDIR:-/tmp}/review_response.md"
+# なぜ: mktemp で衝突を避け、trap で失敗時も確実に削除できる
+REVIEW_BODY="$(mktemp "${TMPDIR:-/tmp}/review_response.XXXXXX")" || {
+  echo "レビュー返信用の一時ファイル作成に失敗しました" >&2
+  exit 1
+}
+cleanup_review_body() {
+  [ -n "$REVIEW_BODY" ] && rm -f "$REVIEW_BODY"
+}
+trap cleanup_review_body EXIT
 cat > "$REVIEW_BODY" <<'EOF'
 全レビューコメントに対応済みです。各コミットの詳細を参照してください。
 
@@ -239,7 +246,6 @@ cat > "$REVIEW_BODY" <<'EOF'
 EOF
 
 gh pr review --comment --body-file "$REVIEW_BODY"
-rm -f "$REVIEW_BODY"
 
 # 特定のレビューコメントスレッドへの返信はGitHub Web UIを使用
 # またはAPI: gh api repos/OWNER/REPO/pulls/comments/COMMENT_ID/replies -f body="abc1234で修正済み"
@@ -273,7 +279,14 @@ gh pr review --comment --body "全レビューコメントに対応済み。各�
 gh pr edit --add-reviewer reviewer-username
 
 # サマリーコメントを body-file で残す（任意）
-REREVIEW_BODY="${TMPDIR:-/tmp}/rereview_summary.md"
+REREVIEW_BODY="$(mktemp "${TMPDIR:-/tmp}/rereview_summary.XXXXXX")" || {
+  echo "再レビュー要約用の一時ファイル作成に失敗しました" >&2
+  exit 1
+}
+cleanup_rereview_body() {
+  [ -n "$REREVIEW_BODY" ] && rm -f "$REREVIEW_BODY"
+}
+trap cleanup_rereview_body EXIT
 cat > "$REREVIEW_BODY" <<'EOF'
 すべてのレビューコメントに対応しました：
 - SQLインジェクション修正（コミットabc1234）
@@ -284,7 +297,6 @@ cat > "$REREVIEW_BODY" <<'EOF'
 EOF
 
 gh pr comment --body-file "$REREVIEW_BODY"
-rm -f "$REREVIEW_BODY"
 ```
 
 ```powershell

--- a/skills/github-pr-workflow/SKILL.md
+++ b/skills/github-pr-workflow/SKILL.md
@@ -158,9 +158,16 @@ Refs #130"
 **File-based body** (recommended default for multiline Markdown, code fences, or backticks):
 
 ```bash
-# Write body to a temp file with a quoted heredoc.
-# Why: single-quoted EOF prevents shell expansion of backticks, $vars, and $(command).
-BODY_FILE="${TMPDIR:-/tmp}/pr_body.md"
+# Write body to a unique temp file with a quoted heredoc.
+# Why: mktemp avoids filename collisions, and trap cleans up on failure paths too.
+BODY_FILE="$(mktemp "${TMPDIR:-/tmp}/pr_body.XXXXXX")" || {
+  echo "Failed to create temporary file for PR body" >&2
+  exit 1
+}
+cleanup() {
+  [ -n "$BODY_FILE" ] && rm -f "$BODY_FILE"
+}
+trap cleanup EXIT
 cat > "$BODY_FILE" <<'EOF'
 ## 概要
 注文履歴画面に検索フィルタを追加し、本文内の `int(order_id)` 例もそのまま残す。
@@ -177,7 +184,6 @@ Refs #130
 EOF
 
 gh pr create --title "feat: 支払い画面にフィルタを追加" --body-file "$BODY_FILE"
-rm -f "$BODY_FILE"
 ```
 
 Prefer this pattern for any non-trivial body, especially when Markdown contains backticks, shell examples, or multiple paragraphs.
@@ -203,7 +209,7 @@ Use when the branch is pushed and no PR exists yet.
 - Use Conventional Commits format for titles (`feat:`, `fix:`, etc.)
 - Always include `Closes #N` to auto-close linked issues
 - Prefer `--body-file` for any multiline or shell-sensitive body; on Windows, make it the default
-- Use a single-quoted heredoc (`<<'EOF'`) when generating body files in Bash
+- Use `mktemp` + `trap` with a single-quoted heredoc (`<<'EOF'`) when generating body files in Bash
 - Verify authentication with `gh auth status` before creating PRs
 
 ### Preflight Checklist (Before `gh pr create`)

--- a/skills/github-pr-workflow/references/SKILL.ja.md
+++ b/skills/github-pr-workflow/references/SKILL.ja.md
@@ -1,6 +1,6 @@
 ---
 name: github-pr-workflow
-description: "Use when リポジトリ状態からPRを作成し、Issue連携まで安全に進めたいとき。"
+description: "リポジトリ状態からPRを作成し、Issue連携まで安全に進めたいときに使用します。"
 metadata:
   author: RyoMurakami1983
   tags: [github, pull-requests, workflow, git, pr-create]
@@ -158,9 +158,16 @@ Refs #130"
 **ファイル経由の本文**（複数行Markdown・コードフェンス・バッククォートを含む本文の既定推奨）:
 
 ```bash
-# クォート付きHEREDOCで一時ファイルへ書き出す
-# なぜ: `<<'EOF'` ならバッククォート、$変数、$(command) をシェル展開しない
-BODY_FILE="${TMPDIR:-/tmp}/pr_body.md"
+# 一意な一時ファイルを作り、クォート付きHEREDOCで書き出す
+# なぜ: mktemp で衝突を避け、trap で失敗時も確実に削除できる
+BODY_FILE="$(mktemp "${TMPDIR:-/tmp}/pr_body.XXXXXX")" || {
+  echo "PR本文用の一時ファイル作成に失敗しました" >&2
+  exit 1
+}
+cleanup() {
+  [ -n "$BODY_FILE" ] && rm -f "$BODY_FILE"
+}
+trap cleanup EXIT
 cat > "$BODY_FILE" <<'EOF'
 ## 概要
 注文履歴画面に検索フィルタを追加し、本文内の `int(order_id)` 例もそのまま残す。
@@ -177,7 +184,6 @@ Refs #130
 EOF
 
 gh pr create --title "feat: 支払い画面にフィルタを追加" --body-file "$BODY_FILE"
-rm -f "$BODY_FILE"
 ```
 
 複数段落の本文、シェル例、バッククォートを含むMarkdownでは、このパターンを既定にしてください。
@@ -203,7 +209,7 @@ Why: ファイル経由の方が再現性・レビュー性・シェル安全性
 - タイトルは Conventional Commits 形式（`feat:`, `fix:` 等）
 - `Closes #N` で Issue を自動クローズする
 - 複数行やシェルに敏感な本文では `--body-file` を既定にする（Windows では必須寄り）
-- Bashで本文ファイルを作るときはクォート付きHEREDOC（`<<'EOF'`）を使う
+- Bashで本文ファイルを作るときは `mktemp` + `trap` とクォート付きHEREDOC（`<<'EOF'`）を使う
 - `gh auth status` で認証を事前確認する
 
 ### 事前チェックリスト（`gh pr create` 前）


### PR DESCRIPTION
## 概要
- `github-pr-workflow` にクォート付きHEREDOC + `--body-file` の安全パターンを追加
- `github-pr-review-response` にレビュー返信・再レビュー要約の body-file 運用を追加
- EN/JA の説明を同期し、`github-pr-workflow` の validator PASS 条件も満たす形へ整理

## 理由
- `gh --body` に複数行Markdownやバッククォートを直接渡すと、シェル展開やクォート崩れで本文が壊れやすいため
- PR本文とレビュー返信の両方で安全な標準手順を明文化したいため

## テスト
- [x] `python3 skills/skill-quality-validation/scripts/validate_skill.py skills/github-pr-workflow/SKILL.md` (93.3% PASS)
- [x] `python3 skills/skill-quality-validation/scripts/validate_skill.py skills/github-pr-review-response/SKILL.md` (98.3% PASS)
- [x] `./node_modules/.bin/textlint <changed files>`

## 関連
Closes #111
