### PR TITLE
feat(notion): add auth expiry re-authentication guidance

### DIFF
--- a/skills/notion-safe-operations/SKILL.md
+++ b/skills/notion-safe-operations/SKILL.md
@@ -65,7 +65,7 @@ notion-notion-fetch(id="collection://<your-data-source-id>")
 | Signal | Decision |
 |---|---|
 | Fetch succeeds | Continue to Step 2 |
-| Error contains "unauthorized" / "401" / "authentication" | Auth expired → ask user to run `/mcp r` then retry |
+| Error contains "unauthorized" / "401" / "authentication" | Auth expired → ask user to run `/mcp r`, then re-run the Step 1 preflight fetch (retry Step 1) |
 | Tool missing / fetch fails (other) | Stop writes and use Step 5 fallback |
 
 Why: `/mcp show` can list integrations while current runtime still cannot invoke the tool.
@@ -201,7 +201,7 @@ Why: a structured fallback preserves momentum even when tools are unstable.
 | DS ID unknown | Run Step 2 resolution flow |
 | Property error occurs | Re-run Step 3 schema check |
 | Auth expired (401 / unauthorized) | Run `/mcp r` to re-authenticate, then retry Step 1 |
-| Tool call fails in runtime | Use Step 5 fallback payload |
+| Tool call fails in runtime (non-auth error) | Use Step 5 fallback payload |
 
 ### Minimal Checklist
 

--- a/skills/notion-safe-operations/references/SKILL.ja.md
+++ b/skills/notion-safe-operations/references/SKILL.ja.md
@@ -65,7 +65,7 @@ notion-notion-fetch(id="collection://<your-data-source-id>")
 | シグナル | 判断 |
 |---|---|
 | fetch成功 | Step 2へ進む |
-| "unauthorized" / "401" / "authentication" を含むエラー | 認証切れ → ユーザーに `/mcp r` を実行するよう案内 |
+| "unauthorized" / "401" / "authentication" を含むエラー | 認証切れ → ユーザーに `/mcp r` を実行するよう案内 → 再認証後に Step 1 を再実行 |
 | ツール未検出/その他失敗 | Step 5フォールバックへ |
 
 **なぜ？** `/mcp show` で見えても、実行コンテキストで呼べない場合があるため。


### PR DESCRIPTION
- Step 1 Decision Table: add auth expired / 401 row → /mcp r
- Step 5 fallback: split auth-expired vs other failures with /mcp r instruction
- Quick Reference Decision Table: add auth expired row
- FAQ: add 'What if Notion auth expires?' Q&A
- EN and JA updated in parity

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
