### PR TITLE
docs(github-issue): add Japanese issue policy

### DIFF
--- a/skills/github-issue-intake/SKILL.md
+++ b/skills/github-issue-intake/SKILL.md
@@ -59,7 +59,7 @@ Determine whether to fix inline or defer. Use a simple decision matrix based on 
 
 ```text
 # ✅ CORRECT - File issue when out of scope
-Issue: "Bug: CSV import fails on UTF-8 BOM"
+Issue: "🟡 CSV import: UTF-8 BOM を受け付けない"
 Scope: Not required for current PR
 Action: Create issue and continue
 
@@ -157,7 +157,7 @@ Assign labels for type, priority, and area so the backlog is sortable. At minimu
 
 ```yaml
 # ✅ CORRECT
-labels: [bug, priority/P1, area/import]
+labels: [t/bug, p/high, a/import]
 
 # ❌ WRONG
 labels: []
@@ -196,7 +196,7 @@ Use `gh issue create` for fast, repeatable creation, and `gh issue edit` to refa
 gh issue create \
   --title "🟢 github-issue-intake: Issueは日本語で起票する方針を明記する" \
   --body-file issue.md \
-  --label enhancement,a/skills,t/chore \
+  --label t/chore,p/medium,a/skills \
   --assignee @me
 
 # Edit
@@ -302,7 +302,7 @@ Fix: Prefer `--body-file` with UTF-8 for CLI edits.
 A: File an issue when the fix is out of scope or exceeds your timebox.
 
 **Q: What labels are mandatory?**
-A: At minimum, include type and priority labels.
+A: At minimum, include one type label (`t/*`) and one priority label (`p/*`).
 
 **Q: Should issues in this repository be written in Japanese or English?**
 A: Default to Japanese for titles and bodies. Keep proper nouns, CLI commands, code identifiers, and external service names in English when that improves recognition.
@@ -327,7 +327,7 @@ A: Yes — treat it as backlog maintenance. Update title/body (and add DoD) so t
 
 ```bash
 # CLI quick create
-gh issue create --title "🟢 改善: ..." --body-file issue.md --label enhancement,a/skills
+gh issue create --title "🟢 改善: ..." --body-file issue.md --label t/feature,p/medium,a/skills
 
 # CLI quick edit
 gh issue edit 123 --title "🟢 〜を明記する" --body-file issue.md

--- a/skills/github-issue-intake/references/SKILL.ja.md
+++ b/skills/github-issue-intake/references/SKILL.ja.md
@@ -59,7 +59,7 @@ metadata:
 
 ```text
 # ✅ CORRECT - スコープ外はIssue化
-Issue: "Bug: CSV import fails on UTF-8 BOM"
+Issue: "🟡 CSV import: UTF-8 BOM を受け付けない"
 Scope: 現PRでは不要
 Action: Issueを作成して続行
 
@@ -156,7 +156,7 @@ Issue の言語方針が明文化されておらず、起票者ごとに英語 /
 
 ```yaml
 # ✅ CORRECT
-labels: [bug, priority/P1, area/import]
+labels: [t/bug, p/high, a/import]
 
 # ❌ WRONG
 labels: []
@@ -195,7 +195,7 @@ Log: 2026-02-12T12:03:11Z ERROR import failed (BOM detected)
 gh issue create \
   --title "🟢 github-issue-intake: Issueは日本語で起票する方針を明記する" \
   --body-file issue.md \
-  --label enhancement,a/skills,t/chore \
+  --label t/chore,p/medium,a/skills \
   --assignee @me
 
 # 更新（具体化）
@@ -305,6 +305,9 @@ A: コメントで済ませず、title/bodyを具体化（背景・目的・DoD�
 **Q: このリポジトリのIssueは日本語と英語のどちらで書くべき？**
 A: 既定は日本語。固有名詞・CLI コマンド・コード識別子・外部サービス名は、認知しやすさを優先して英語のまま使ってよい。
 
+**Q: 最低限必要なラベルは？**
+A: 少なくとも種別ラベル（`t/*`）を1つと、優先度ラベル（`p/*`）を1つ付ける。
+
 ---
 
 ## クイックリファレンス
@@ -323,7 +326,7 @@ A: 既定は日本語。固有名詞・CLI コマンド・コード識別子・�
 ---
 ```bash
 # CLI で新規作成
-gh issue create --title "🟢 改善: ..." --body-file issue.md --label enhancement,a/skills
+gh issue create --title "🟢 改善: ..." --body-file issue.md --label t/feature,p/medium,a/skills
 
 # CLI で更新
 gh issue edit 123 --title "🟢 〜を明記する" --body-file issue.md


### PR DESCRIPTION
## 概要
`github-issue-intake` に、このリポジトリでは Issue を日本語で起票する既定方針を追加しました。
固有名詞、CLI コマンド、コード識別子、外部サービス名は認知しやすさを優先して英語を維持できるよう、EN/JA 両方の説明・例・FAQ を更新しています。

## 理由
Issue #123 / #124 を英語で起票した後に日本語へ修正する手戻りが発生し、Issue 起票の言語方針を skill に明文化する必要があったためです。

## テスト
- `python3 skills/skill-quality-validation/scripts/validate_skill.py skills/github-issue-intake/SKILL.md`
- `npx --yes textlint skills/github-issue-intake/SKILL.md skills/github-issue-intake/references/SKILL.ja.md`
- EN/JA parity check (`##` / `### Step` count)

## 関連
Closes #125
