### PR TITLE
docs: Tier 3 パターン型ドキュメント追加 (T3-1/T3-2/T3-3)

### DIFF
--- a/agents/skill-shihan.agent.md
+++ b/agents/skill-shihan.agent.md
@@ -94,8 +94,9 @@ skill-shihan がオーナーとして品質管理を担当する。
 ## 品質基準（先生モードで使用）
 
 ### フロントマター
-- トップレベル許可キー: `name`, `description`, `tools`
-- `metadata:` ブロック（author/tags/invocable/tool_versions 等）は**廃止** → フロントマターは `name` + `description` のみ
+- **SKILL.md** のトップレベル許可キー: `name`, `description`（これのみ）
+- **agent.md** のトップレベル許可キー: `name`, `description`, `tools`（エージェント専用）
+- `metadata:` ブロック（author/tags/invocable/tool_versions 等）は**廃止** → フロントマターは `name` + `description`（SKILL.md）または `name` + `description` + `tools`（agent.md）のみ
 - `description` ≤1024文字、"Use when" トリガーフレーズ必須（W7 警告: ≥80文字、action verb、capability列挙）
 
 ### 構造

--- a/docs/patterns/environment-portability.md
+++ b/docs/patterns/environment-portability.md
@@ -105,7 +105,7 @@ PowerShell 専用の機能で Bash フォールバックが困難な場合。
 
 ```powershell
 # PowerShell（推奨）
-$result = Get-Content output.json | ConvertFrom-Json
+$result = Get-Content -Raw output.json | ConvertFrom-Json
 $result.items | ForEach-Object { Write-Host $_.name }
 ```
 
@@ -126,7 +126,7 @@ jq -r '.items[].name' output.json
 ```bash
 #!/usr/bin/env bash
 # Detect OS and set appropriate temp directory
-if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" ]]; then
+if [[ "$OSTYPE" =~ ^msys ]] || [[ "$OSTYPE" =~ ^cygwin ]]; then
     # Git Bash on Windows
     TEMP_DIR="${TEMP:-/tmp}"
 else

--- a/docs/patterns/sub-agent-delegation.md
+++ b/docs/patterns/sub-agent-delegation.md
@@ -25,7 +25,7 @@
 │  機能レイヤー（Function Layer）                          │
 │  自己文書化・特化・再利用可能                            │
 │                                                         │
-│  grader.md  reviewer.md  formatter.md  validator.md     │
+│  grader.agent.md  reviewer.agent.md  formatter.agent.md  validator.agent.md  │
 └─────────────────────────────────────────────────────────┘
 ```
 

--- a/skills/skill-quality-validation/references/schemas.md
+++ b/skills/skill-quality-validation/references/schemas.md
@@ -14,14 +14,14 @@
 ```yaml
 ---
 name: "skill-name"        # 必須: kebab-case、スキルディレクトリ名と一致
-description: "..."        # 必須: 80〜1024文字、"use when" トリガーフレーズ含む
+description: "..."        # 必須: ≤1024文字、"use when" トリガーフレーズ含む（W7.1警告: 80文字未満は品質警告）
 ---
 ```
 
-### 禁止フィールド（top-level）
+### 非推奨フィールド（top-level）
 
 ```yaml
-# ❌ これらはトップレベルに置かない
+# ⚠️ これらはトップレベルに置かない（validate_skill.py では fail にならないが非推奨）
 version: "1.0.0"          # → git tag / CHANGELOG で管理
 author: "name"            # → git blame で管理
 tags: [...]               # → 現在どのシステムでも使用されていない
@@ -33,6 +33,7 @@ last_reviewed: "..."      # → git log で確認可能
 
 > **背景（温故知新）**: metadata: ブロックは Tier 1 アップデート（2026-02）で廃止。
 > 帰属・バージョン管理は git の責任領域。フロントマターは「発見」のためだけに使う。
+> これらのフィールドが存在しても `validate_skill.py` は fail にしない（check 1.2b/1.2c は廃止済み）。
 
 ### description フォーマット推奨（W7 警告対象）
 
@@ -67,11 +68,12 @@ description: >
 | セクション | 要件 | チェックID |
 |-----------|------|-----------|
 | `## When to Use This Skill` | 最初のH2であること | 1.5 |
-| `## Core Principles` | 番号付きリスト形式 | 1.8 |
-| `## Best Practices` | セクション存在 | 1.9 |
-| `## Anti-Patterns` | セクション存在 | 1.10 |
-| `## Quick Reference` | セクション存在 | 1.11 |
-| `references/SKILL.ja.md` | 対応する日本語版 | 1.12, 1.13 |
+| `## Core Principles / The Philosophy` | 番号付きリスト形式 | 1.6 |
+| `## Best Practices` | セクション存在 | 1.7 |
+| `## Common Pitfalls` | セクション存在 | 1.8 |
+| `## Anti-Patterns` | セクション存在 | 1.9 |
+| `## Quick Reference / Decision Tree` | セクション存在 | 1.10 |
+| `references/SKILL.ja.md` | 対応する日本語版（構造・内容パリティ） | 1.11〜1.13 |
 
 ### Core Principles フォーマット
 
@@ -124,14 +126,16 @@ $result = gh pr list --json state | ConvertFrom-Json
 
 ## Language 品質契約
 
-### 4.1〜4.4 の基準
+### 4.1〜4.4 の基準（設計意図・未実装）
 
-| チェック | 閾値 | 測定方法 |
-|---------|------|---------|
-| 能動態比率 | passive < 20% | passive 表現のカウント |
-| "should" 乱用回避 | < 5回 | 文書内出現回数 |
-| Headers に be 動詞禁止 | 0件 | 見出し内の be 動詞チェック |
-| ファイルサイズ | ≤ 500行 | wc -l |
+> **NOTE**: 現在の `validate_skill.py` の `LanguageValidator` は 4.1.1〜4.3.3（受動態比率 / 長文 / 命令形 / 曖昧語 / 定義 / 頭字語 / 見出し数 / 表の可読性 / 強調）のみを実装しており、以下のチェックは**設計意図（未実装）**である。将来の実装時の目標値として扱い、現時点の pass/fail 判定には影響しない。
+
+| チェック | 閾値 | 測定方法 | 実装状況 |
+|---------|------|---------|----------|
+| 能動態比率 | passive < 20% | passive 表現のカウント | 未実装（設計意図） |
+| "should" 乱用回避 | < 5回 | 文書内出現回数 | 未実装（設計意図） |
+| Headers に be 動詞禁止 | 0件 | 見出し内の be 動詞チェック | 未実装（設計意図） |
+| ファイルサイズ | ≤ 500行 | 行数カウント（現状は check 1.13 で管理） | 未実装（設計意図） |
 
 ---
 
@@ -184,5 +188,5 @@ uv run python skills/skill-quality-validation/scripts/validate_skill.py <path> -
 uv run python skills/skill-quality-validation/scripts/analyze_skill_gaps.py
 ```
 
-**前提条件**: プロジェクトルートから実行すること。
-`validate_skill.py` は `skills/` ルートへの相対パスを自動検出する。
+**前提条件**: 検証したい SKILL.md へのパスを正しく指定すること（カレントディレクトリには依存しない）。
+`validate_skill.py` は与えられた SKILL.md の場所から上方向に `.github/copilot-instructions.md` を探索し、その位置をリポジトリルートとして扱う。


### PR DESCRIPTION
## 概要
Tier 3 のパターン型ドキュメントを3つ追加。
skills_repository の設計思想と「型」を明文化し、
将来のスキル・エージェント作成の一貫性を保証する。

## 変更内容

### T3-1: docs/patterns/sub-agent-delegation.md（新規）
師範エージェントが特化型サブエージェントに委譲する「型」を定義。

- 二層構造（師範レイヤー/機能レイヤー）の設計思想
- 命名規則: 師範は {domain}-shihan、機能は {role}.agent.md
- 3つの委譲パターン: タスク特化・パイプライン・コンテキスト保持
- 機能エージェントのテンプレートとチェックリスト

また、gents/skill-shihan.agent.md のフロントマター品質基準を
T1（metadata廃止）に合わせて更新。

### T3-2: skills/skill-quality-validation/references/schemas.md（新規）
alidate_skill.py と SKILL.md 作成者の間の「契約」を明文化。

- フロントマター必須/禁止フィールド一覧
- description フォーマット推奨パターン（W7 警告条件含む）
- 構造・コード品質・Language の各契約
- スコアリング契約（85%/80% ルールの根拠）
- バリデーション実行コマンドリファレンス

### T3-3: docs/patterns/environment-portability.md（新規）
SKILL.md のコードブロックで複数OS・シェルに対応する標準テンプレート。

- 5つの標準テンプレート（共通/両対応/パス変数/条件分岐/OS判定）
- PowerShell vs Bash 対応表（変数・条件分岐・JSON・エラー処理等）
- 3つのフォールバック指示パターン

## 理由
gap-analysis 最大ボトルネック「Progressive Disclosure (42%)」への対応完了。
Tier 1〜3 を通じた設計判断と「型」をすべてドキュメント化した。

## テスト
- 既存スキルへの破壊的変更なし（ドキュメント追加のみ）
- skill-shihan.agent.md の変更はフロントマター品質基準の文言修正のみ

## 関連
- T2-3 (PR #150) と独立した変更
- T3-4 (description最適化支援ツール) は将来課題として保留
